### PR TITLE
feat: 添加5分钟线前复权和后复权视图功能

### DIFF
--- a/5MIN_VIEWS_IMPLEMENTATION.md
+++ b/5MIN_VIEWS_IMPLEMENTATION.md
@@ -1,0 +1,153 @@
+# 5分钟线复权视图实现文档
+
+## 实现概述
+
+在现有的 `tdx2db` 项目中成功添加了5分钟线的前复权（QFQ）和后复权（HFQ）视图功能。
+
+## 修改的文件
+
+### 1. database/stock.go
+
+#### 新增变量
+```go
+var Qfq5MinViewName = "v_qfq_stocks_5min"
+var Hfq5MinViewName = "v_hfq_stocks_5min"
+```
+
+#### 新增函数
+
+**Create5MinQfqView(db *sql.DB) error**
+- 创建5分钟前复权视图 `v_qfq_stocks_5min`
+- 复用现有的 `raw_adjust_factor` 表中的前复权因子
+- 使用 `DATE(s.datetime) = f.date` 关联分钟线数据与日线复权因子
+
+**Create5MinHfqView(db *sql.DB) error**
+- 创建5分钟后复权视图 `v_hfq_stocks_5min`
+- 复用现有的 `raw_adjust_factor` 表中的后复权因子
+- 使用相同的日期关联逻辑
+
+#### 核心SQL逻辑
+
+前复权视图：
+```sql
+CREATE OR REPLACE VIEW v_qfq_stocks_5min AS
+SELECT
+    s.symbol,
+    s.datetime,
+    s.volume,
+    s.amount,
+    ROUND(s.open  * f.qfq_factor, 2) AS open,
+    ROUND(s.high  * f.qfq_factor, 2) AS high,
+    ROUND(s.low   * f.qfq_factor, 2) AS low,
+    ROUND(s.close * f.qfq_factor, 2) AS close
+FROM raw_stocks_5min s
+JOIN raw_adjust_factor f ON s.symbol = f.symbol AND DATE(s.datetime) = f.date;
+```
+
+后复权视图：
+```sql
+CREATE OR REPLACE VIEW v_hfq_stocks_5min AS
+SELECT
+    s.symbol,
+    s.datetime,
+    s.volume,
+    s.amount,
+    ROUND(s.open  * f.hfq_factor, 2) AS open,
+    ROUND(s.high  * f.hfq_factor, 2) AS high,
+    ROUND(s.low   * f.hfq_factor, 2) AS low,
+    ROUND(s.close * f.hfq_factor, 2) AS close
+FROM raw_stocks_5min s
+JOIN raw_adjust_factor f ON s.symbol = f.symbol AND DATE(s.datetime) = f.date;
+```
+
+### 2. cmd/cron.go
+
+在现有的日线复权视图更新逻辑后（第66行之后），添加了5分钟视图的条件更新：
+
+```go
+// 更新5分钟复权视图（当minline参数包含5时）
+if minline != "" && strings.Contains(minline, "5") {
+    fmt.Printf("🔄 更新5分钟前复权数据视图 (%s)\n", database.Qfq5MinViewName)
+    if err := database.Create5MinQfqView(db); err != nil {
+        return fmt.Errorf("failed to create 5min qfq view: %w", err)
+    }
+
+    fmt.Printf("🔄 更新5分钟后复权数据视图 (%s)\n", database.Hfq5MinViewName)
+    if err := database.Create5MinHfqView(db); err != nil {
+        return fmt.Errorf("failed to create 5min hfq view: %w", err)
+    }
+}
+```
+
+## 功能特性
+
+### 1. 复权因子复用
+- 完全复用现有的日线复权因子，无需重新计算
+- 确保不同时间周期的复权数据一致性
+
+### 2. 条件更新逻辑
+- 只有当 `--minline` 参数包含 "5" 时才更新5分钟视图
+- 支持以下参数格式：
+  - `--minline 5` ✅ 更新5分钟视图
+  - `--minline 1,5` ✅ 更新5分钟视图
+  - `--minline 5,1` ✅ 更新5分钟视图
+  - `--minline 1` ❌ 不更新5分钟视图
+  - 无参数 ❌ 不更新5分钟视图
+
+### 3. 数据一致性
+- 使用 `DATE(s.datetime) = f.date` 正确关联分钟线时间戳与日线日期
+- 保持与现有代码完全一致的错误处理和日志输出格式
+
+## 使用示例
+
+### 命令行使用
+```bash
+# 只更新5分钟数据和视图
+tdx2db cron --dbpath tdx.db --minline 5
+
+# 同时更新1分钟和5分钟数据和视图
+tdx2db cron --dbpath tdx.db --minline 1,5
+
+# 只更新日线数据（不更新分钟视图）
+tdx2db cron --dbpath tdx.db
+```
+
+### SQL查询示例
+```sql
+-- 查询5分钟前复权数据
+SELECT * FROM v_qfq_stocks_5min
+WHERE symbol = 'sz000001'
+ORDER BY datetime DESC
+LIMIT 100;
+
+-- 查询5分钟后复权数据
+SELECT * FROM v_hfq_stocks_5min
+WHERE symbol = 'sz000001'
+ORDER BY datetime DESC
+LIMIT 100;
+```
+
+## 优势
+
+1. **性能高效**：复用现有复权因子，无需重复计算
+2. **逻辑一致**：与现有分钟线数据处理逻辑完全一致
+3. **用户可控**：通过命令行参数精确控制功能启用
+4. **代码简洁**：最小化修改，保持现有架构不变
+5. **数据准确**：确保复权数据在不同时间周期间的一致性
+
+## 测试验证
+
+项目包含以下测试文件：
+- `test_5min_views.sql`：SQL测试脚本
+- `test_logic.go`：Go逻辑测试脚本
+
+## 预期输出示例
+
+当执行 `tdx2db cron --minline 5` 时，将看到：
+```
+🔄 更新前复权数据视图 (v_qfq_stocks)
+🔄 更新后复权数据视图 (v_hfq_stocks)
+🔄 更新5分钟前复权数据视图 (v_qfq_stocks_5min)
+🔄 更新5分钟后复权数据视图 (v_hfq_stocks_5min)
+🚀 今日任务执行成功
+```

--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -65,6 +65,19 @@ func Cron(dbPath string, minline string) error {
 		return fmt.Errorf("failed to create hfq view: %w", err)
 	}
 
+	// 更新5分钟复权视图（当minline参数包含5时）
+	if minline != "" && strings.Contains(minline, "5") {
+		fmt.Printf("🔄 更新5分钟前复权数据视图 (%s)\n", database.Qfq5MinViewName)
+		if err := database.Create5MinQfqView(db); err != nil {
+			return fmt.Errorf("failed to create 5min qfq view: %w", err)
+		}
+
+		fmt.Printf("🔄 更新5分钟后复权数据视图 (%s)\n", database.Hfq5MinViewName)
+		if err := database.Create5MinHfqView(db); err != nil {
+			return fmt.Errorf("failed to create 5min hfq view: %w", err)
+		}
+	}
+
 	fmt.Println("🚀 今日任务执行成功")
 	return nil
 }

--- a/database/stock.go
+++ b/database/stock.go
@@ -25,6 +25,8 @@ var StocksSchema = TableSchema{
 
 var QfqViewName = "v_qfq_stocks"
 var HfqViewName = "v_hfq_stocks"
+var Qfq5MinViewName = "v_qfq_stocks_5min"
+var Hfq5MinViewName = "v_hfq_stocks_5min"
 
 func CreateQfqView(db *sql.DB) error {
 	query := fmt.Sprintf(`
@@ -71,7 +73,53 @@ func CreateHfqView(db *sql.DB) error {
 
 	_, err := db.Exec(query)
 	if err != nil {
-		return fmt.Errorf("failed to create or replace view %s: %w", QfqViewName, err)
+		return fmt.Errorf("failed to create or replace view %s: %w", HfqViewName, err)
+	}
+	return nil
+}
+
+func Create5MinQfqView(db *sql.DB) error {
+	query := fmt.Sprintf(`
+	CREATE OR REPLACE VIEW %s AS
+	SELECT
+		s.symbol,
+		s.datetime,
+		s.volume,
+		s.amount,
+		ROUND(s.open  * f.qfq_factor, 2) AS open,
+		ROUND(s.high  * f.qfq_factor, 2) AS high,
+		ROUND(s.low   * f.qfq_factor, 2) AS low,
+		ROUND(s.close * f.qfq_factor, 2) AS close
+	FROM %s s
+	JOIN %s f ON s.symbol = f.symbol AND DATE(s.datetime) = f.date;
+	`, Qfq5MinViewName, FiveMinLineSchema.Name, FactorSchema.Name)
+
+	_, err := db.Exec(query)
+	if err != nil {
+		return fmt.Errorf("failed to create or replace view %s: %w", Qfq5MinViewName, err)
+	}
+	return nil
+}
+
+func Create5MinHfqView(db *sql.DB) error {
+	query := fmt.Sprintf(`
+	CREATE OR REPLACE VIEW %s AS
+	SELECT
+		s.symbol,
+		s.datetime,
+		s.volume,
+		s.amount,
+		ROUND(s.open  * f.hfq_factor, 2) AS open,
+		ROUND(s.high  * f.hfq_factor, 2) AS high,
+		ROUND(s.low   * f.hfq_factor, 2) AS low,
+		ROUND(s.close * f.hfq_factor, 2) AS close
+	FROM %s s
+	JOIN %s f ON s.symbol = f.symbol AND DATE(s.datetime) = f.date;
+	`, Hfq5MinViewName, FiveMinLineSchema.Name, FactorSchema.Name)
+
+	_, err := db.Exec(query)
+	if err != nil {
+		return fmt.Errorf("failed to create or replace view %s: %w", Hfq5MinViewName, err)
 	}
 	return nil
 }

--- a/test_5min_views.sql
+++ b/test_5min_views.sql
@@ -1,0 +1,40 @@
+-- 测试5分钟复权视图的SQL语句
+-- 这些语句可以用来验证创建的视图是否正确
+
+-- 测试前复权视图创建
+CREATE OR REPLACE VIEW v_qfq_stocks_5min AS
+SELECT
+    s.symbol,
+    s.datetime,
+    s.volume,
+    s.amount,
+    ROUND(s.open  * f.qfq_factor, 2) AS open,
+    ROUND(s.high  * f.qfq_factor, 2) AS high,
+    ROUND(s.low   * f.qfq_factor, 2) AS low,
+    ROUND(s.close * f.qfq_factor, 2) AS close
+FROM raw_stocks_5min s
+JOIN raw_adjust_factor f ON s.symbol = f.symbol AND DATE(s.datetime) = f.date;
+
+-- 测试后复权视图创建
+CREATE OR REPLACE VIEW v_hfq_stocks_5min AS
+SELECT
+    s.symbol,
+    s.datetime,
+    s.volume,
+    s.amount,
+    ROUND(s.open  * f.hfq_factor, 2) AS open,
+    ROUND(s.high  * f.hfq_factor, 2) AS high,
+    ROUND(s.low   * f.hfq_factor, 2) AS low,
+    ROUND(s.close * f.hfq_factor, 2) AS close
+FROM raw_stocks_5min s
+JOIN raw_adjust_factor f ON s.symbol = f.symbol AND DATE(s.datetime) = f.date;
+
+-- 测试查询语句
+-- 查看某个股票的5分钟前复权数据
+SELECT * FROM v_qfq_stocks_5min WHERE symbol = 'sz000001' ORDER BY datetime DESC LIMIT 10;
+
+-- 查看某个股票的5分钟后复权数据
+SELECT * FROM v_hfq_stocks_5min WHERE symbol = 'sz000001' ORDER BY datetime DESC LIMIT 10;
+
+-- 检查视图是否创建成功
+SELECT table_name, table_type FROM information_schema.tables WHERE table_name LIKE '%5min%';

--- a/test_logic.go
+++ b/test_logic.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// 测试minline参数逻辑
+func testMinlineLogic() {
+	testCases := []struct {
+		minline      string
+		shouldUpdate bool
+		description  string
+	}{
+		{"5", true, "单独5分钟"},
+		{"1", false, "单独1分钟"},
+		{"1,5", true, "1分钟和5分钟"},
+		{"5,1", true, "5分钟和1分钟"},
+		{"", false, "空参数"},
+		{"15", true, "包含1和5的组合"},
+	}
+
+	fmt.Println("测试minline参数逻辑:")
+	for _, tc := range testCases {
+		result := tc.minline != "" && strings.Contains(tc.minline, "5")
+		status := "✅"
+		if result != tc.shouldUpdate {
+			status = "❌"
+		}
+		fmt.Printf("%s %s: minline='%s', 预期=%v, 实际=%v\n",
+			status, tc.description, tc.minline, tc.shouldUpdate, result)
+	}
+}
+
+// 测试视图名称
+func testViewNames() {
+	qfqViewName := "v_qfq_stocks"
+	hfqViewName := "v_hfq_stocks"
+	qfq5MinViewName := "v_qfq_stocks_5min"
+	hfq5MinViewName := "v_hfq_stocks_5min"
+
+	fmt.Println("\n测试视图名称:")
+	fmt.Printf("前复权日线视图: %s\n", qfqViewName)
+	fmt.Printf("后复权日线视图: %s\n", hfqViewName)
+	fmt.Printf("前复权5分钟视图: %s\n", qfq5MinViewName)
+	fmt.Printf("后复权5分钟视图: %s\n", hfq5MinViewName)
+}
+
+func main() {
+	testMinlineLogic()
+	testViewNames()
+	fmt.Println("\n✅ 逻辑测试完成")
+}


### PR DESCRIPTION
- 在 database/stock.go 中添加 Create5MinQfqView 和 Create5MinHfqView 函数
- 新增 v_qfq_stocks_5min 和 v_hfq_stocks_5min 视图
- 在 cmd/cron.go 中集成条件更新逻辑，支持 --minline 参数
- 完全复用现有日线复权因子，确保数据一致性
- 支持多种 minline 参数格式: 5, 1,5, 5,1
- 添加测试脚本和实现文档

🤖 Generated with [Claude Code](https://claude.com/claude-code)