### PR TITLE
fix: 修复 volume 溢出分支中 uint32 二次溢出

### DIFF
--- a/tdx/kline.go
+++ b/tdx/kline.go
@@ -202,7 +202,7 @@ func parseDate(d uint32) (time.Time, error) {
 }
 
 // parseVolumeOverflow 处理成交量溢出
-// TDX day 文件中 volume 字段是 uint32，最大约 4.29 亿
+// TDX day 文件中 volume 字段是 uint32，最大约 42.9 亿
 // 当成交量超过此限制时，使用特殊编码:
 //   - reserved (bytes 28-31) 正常值为 0x10000
 //   - 溢出时: volume = volume_raw * 100 + (reserved & 0xFF)
@@ -210,7 +210,7 @@ func parseVolumeOverflow(volRaw, reserved uint32) int64 {
 	if reserved == 0x10000 {
 		return int64(volRaw) // 正常情况
 	}
-	return int64(volRaw*100 + (reserved & 0xFF))
+	return int64(volRaw)*100 + int64(reserved&0xFF)
 }
 
 func parseDateTime(dateRaw, timeRaw uint16) (time.Time, error) {

--- a/tdx/kline_test.go
+++ b/tdx/kline_test.go
@@ -1,0 +1,24 @@
+package tdx
+
+import "testing"
+
+func TestParseVolumeOverflow(t *testing.T) {
+	tests := []struct {
+		name     string
+		volRaw   uint32
+		reserved uint32
+		want     int64
+	}{
+		{"normal", 189_000_000, 0x10000, 189_000_000},
+		{"overflow sh601868 2025-03-12", 478_000_000, 0x00000000, 47_800_000_000},
+		{"overflow with low byte", 478_000_000, 0x0000002A, 47_800_000_042},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseVolumeOverflow(tt.volRaw, tt.reserved)
+			if got != tt.want {
+				t.Errorf("parseVolumeOverflow(%d, 0x%x) = %d, want %d", tt.volRaw, tt.reserved, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
parseVolumeOverflow 在溢出编码分支里用 uint32 做 volRaw*100 计算, 当 volRaw 较大时(例如 sh601868 约 4.78e8)乘 100 会再次超出 uint32 上限, 导致 ClickHouse 中 volume 仍为错误值。改为先转 int64 再运算。

link: https://github.com/jing2uo/tdx2db/pull/64