### PR TITLE
feat: cron 利用 raw_holidays 预判休市与数据新鲜度

### DIFF
--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -32,13 +32,27 @@ func Cron(ctx context.Context, dbURI, minline string) error {
 		return err
 	}
 
+	today := GetToday()
+
+	plan, err := workflow.BuildWorkPlan(db, today)
+	if err != nil {
+		return err
+	}
+	if plan.Reason != "" {
+		fmt.Println(plan.Reason)
+	}
+	if !plan.AnyNeeded() {
+		return nil
+	}
+
 	executor := workflow.NewTaskExecutor(db, workflow.GetRegisteredTasks())
 
 	args := &workflow.TaskArgs{
 		Minline:   minline,
 		TempDir:   TempDir,
 		VipdocDir: VipdocDir,
-		Today:     GetToday(),
+		Today:     today,
+		Plan:      plan,
 	}
 
 	taskNames := workflow.GetUpdateTaskNames()

--- a/database/clickhouse/dml.go
+++ b/database/clickhouse/dml.go
@@ -245,6 +245,15 @@ func (d *ClickHouseDriver) GetGbbq() ([]model.GbbqData, error) {
 	return results, nil
 }
 
+func (d *ClickHouseDriver) GetHolidays() ([]time.Time, error) {
+	query := fmt.Sprintf("SELECT date FROM %s ORDER BY date", model.TableHoliday.TableName)
+	var dates []time.Time
+	if err := d.db.Select(&dates, query); err != nil {
+		return nil, fmt.Errorf("failed to query holidays: %w", err)
+	}
+	return dates, nil
+}
+
 const chMetaTable = "_meta"
 
 func (d *ClickHouseDriver) ReadSchemaVersion() (string, error) {

--- a/database/duckdb/dml.go
+++ b/database/duckdb/dml.go
@@ -223,6 +223,15 @@ func (d *DuckDBDriver) GetGbbq() ([]model.GbbqData, error) {
 	return results, nil
 }
 
+func (d *DuckDBDriver) GetHolidays() ([]time.Time, error) {
+	query := fmt.Sprintf("SELECT date FROM %s ORDER BY date", model.TableHoliday.TableName)
+	var dates []time.Time
+	if err := d.db.Select(&dates, query); err != nil {
+		return nil, fmt.Errorf("failed to query holidays: %w", err)
+	}
+	return dates, nil
+}
+
 const metaTable = "_meta"
 
 func (d *DuckDBDriver) ReadSchemaVersion() (string, error) {

--- a/database/interface.go
+++ b/database/interface.go
@@ -34,4 +34,5 @@ type DataRepository interface {
 	GetBasicsBySymbol(symbol string) ([]model.StockBasic, error)
 
 	GetGbbq() ([]model.GbbqData, error)
+	GetHolidays() ([]time.Time, error)
 }

--- a/workflow/calendar.go
+++ b/workflow/calendar.go
@@ -1,0 +1,41 @@
+package workflow
+
+import "time"
+
+type TradingCalendar struct {
+	holidays map[string]struct{}
+}
+
+func NewTradingCalendar(holidays []time.Time) *TradingCalendar {
+	set := make(map[string]struct{}, len(holidays))
+	for _, d := range holidays {
+		set[d.Format("2006-01-02")] = struct{}{}
+	}
+	return &TradingCalendar{holidays: set}
+}
+
+func (c *TradingCalendar) IsHoliday(d time.Time) bool {
+	_, ok := c.holidays[d.Format("2006-01-02")]
+	return ok
+}
+
+func (c *TradingCalendar) IsWeekend(d time.Time) bool {
+	w := d.Weekday()
+	return w == time.Saturday || w == time.Sunday
+}
+
+func (c *TradingCalendar) IsTradingDay(d time.Time) bool {
+	return !c.IsWeekend(d) && !c.IsHoliday(d)
+}
+
+// LastTradingDayOnOrBefore 返回 ≤ d 的最近交易日。
+func (c *TradingCalendar) LastTradingDayOnOrBefore(d time.Time) time.Time {
+	cur := d
+	for i := 0; i < 30; i++ {
+		if c.IsTradingDay(cur) {
+			return cur
+		}
+		cur = cur.AddDate(0, 0, -1)
+	}
+	return cur
+}

--- a/workflow/engine.go
+++ b/workflow/engine.go
@@ -52,12 +52,13 @@ type Task struct {
 }
 
 type TaskArgs struct {
-	Minline       string
-	TempDir       string
-	VipdocDir     string
-	DayFileDir    string
-	Today         time.Time
-	Extra         map[string]interface{}
+	Minline    string
+	TempDir    string
+	VipdocDir  string
+	DayFileDir string
+	Today      time.Time
+	Plan       *WorkPlan
+	Extra      map[string]interface{}
 }
 
 // TaskExecutor manages and executes tasks with dependency resolution

--- a/workflow/plan.go
+++ b/workflow/plan.go
@@ -1,0 +1,109 @@
+package workflow
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/jing2uo/tdx2db/database"
+	"github.com/jing2uo/tdx2db/model"
+)
+
+// WorkPlan 在任务图启动前汇总交易日历与各表最新日期，决定哪些任务真正需要跑。
+// 任务框架里的 SkipIf 只读取本结构，不再各自重复查询。
+type WorkPlan struct {
+	Today          time.Time
+	LastTradingDay time.Time
+	Calendar       *TradingCalendar
+
+	NeedDaily    bool
+	NeedGbbq     bool
+	NeedBasic    bool
+	NeedFactor   bool
+	NeedHolidays bool
+
+	Reason string // 用于日志
+}
+
+// AnyNeeded 是否有任何任务需要执行。
+func (p *WorkPlan) AnyNeeded() bool {
+	return p.NeedDaily || p.NeedGbbq || p.NeedBasic || p.NeedFactor || p.NeedHolidays
+}
+
+// BuildWorkPlan 读取交易日历与各表最新日期，推导本次 cron 要做什么。
+func BuildWorkPlan(db database.DataRepository, today time.Time) (*WorkPlan, error) {
+	holidays, err := db.GetHolidays()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load holidays: %w", err)
+	}
+
+	plan := &WorkPlan{Today: today}
+
+	// raw_holidays 为空：属于首次运行 / 旧库，放行所有任务让其自行写入节假日。
+	if len(holidays) == 0 {
+		plan.NeedDaily = true
+		plan.NeedGbbq = true
+		plan.NeedBasic = true
+		plan.NeedFactor = true
+		plan.NeedHolidays = true
+		plan.Reason = "raw_holidays 为空，走完整流程"
+		return plan, nil
+	}
+
+	cal := NewTradingCalendar(holidays)
+	plan.Calendar = cal
+	plan.LastTradingDay = cal.LastTradingDayOnOrBefore(today)
+
+	dailyLatest, err := db.GetLatestDate(model.TableKlineDaily.TableName, "date")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest daily date: %w", err)
+	}
+	basicLatest, err := db.GetLatestDate(model.TableBasic.TableName, "date")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest basic date: %w", err)
+	}
+	factorLatest, err := db.GetLatestDate(model.TableAdjustFactor.TableName, "date")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest factor date: %w", err)
+	}
+
+	// 空库：交给 init 流程；此处不标任何 Need，调用方自行决定。
+	if dailyLatest.IsZero() {
+		plan.Reason = "数据库无日线数据，请先运行 init"
+		return plan, nil
+	}
+
+	plan.NeedDaily = dailyLatest.Before(plan.LastTradingDay)
+	// gbbq 与日线同频：日线没新数据时 gbbq 也无须更新。
+	plan.NeedGbbq = plan.NeedDaily
+	// basic/factor 要追赶 daily；如果 daily 将更新，那之后也必须重算。
+	plan.NeedBasic = plan.NeedDaily || basicLatest.Before(dailyLatest)
+	plan.NeedFactor = plan.NeedDaily || factorLatest.Before(basicLatest)
+	// holidays 来自 gbbq.zip，与 gbbq 同频刷新即可。
+	plan.NeedHolidays = plan.NeedGbbq
+
+	plan.Reason = describePlan(plan, dailyLatest)
+	return plan, nil
+}
+
+func describePlan(plan *WorkPlan, dailyLatest time.Time) string {
+	dayStr := plan.Today.Format("2006-01-02")
+	cal := plan.Calendar
+
+	if plan.NeedDaily {
+		return fmt.Sprintf("📅 数据库日线最新 %s，落后于最近交易日 %s，执行更新",
+			dailyLatest.Format("2006-01-02"), plan.LastTradingDay.Format("2006-01-02"))
+	}
+
+	if plan.NeedBasic || plan.NeedFactor {
+		return fmt.Sprintf("📅 日线已是最新 (%s)，补算 basic/factor", dailyLatest.Format("2006-01-02"))
+	}
+
+	switch {
+	case cal.IsHoliday(plan.Today):
+		return fmt.Sprintf("🎉 今日 %s 为节假日，A 股休市，全部任务跳过", dayStr)
+	case cal.IsWeekend(plan.Today):
+		return fmt.Sprintf("🌴 今日 %s 为周末，A 股休市，全部任务跳过", dayStr)
+	default:
+		return fmt.Sprintf("✅ 数据库已是最新 (%s)，全部任务跳过", dailyLatest.Format("2006-01-02"))
+	}
+}

--- a/workflow/tasks.go
+++ b/workflow/tasks.go
@@ -29,6 +29,7 @@ func init() {
 	TaskUpdateDaily = &Task{
 		Name:      "update_daily",
 		DependsOn: []string{},
+		SkipIf:    skipIfPlan(func(p *WorkPlan) bool { return !p.NeedDaily }),
 		Executor:  executeUpdateDaily,
 	}
 
@@ -41,18 +42,21 @@ func init() {
 	TaskUpdateGBBQ = &Task{
 		Name:      "update_gbbq",
 		DependsOn: []string{},
+		SkipIf:    skipIfPlan(func(p *WorkPlan) bool { return !p.NeedGbbq }),
 		Executor:  executeUpdateGBBQ,
 	}
 
 	TaskCalcBasic = &Task{
 		Name:      "calc_basic",
 		DependsOn: []string{"update_daily", "update_gbbq"},
+		SkipIf:    skipIfPlan(func(p *WorkPlan) bool { return !p.NeedBasic }),
 		Executor:  executeCalcBasic,
 	}
 
 	TaskCalcFactor = &Task{
 		Name:      "calc_factor",
 		DependsOn: []string{"calc_basic"},
+		SkipIf:    skipIfPlan(func(p *WorkPlan) bool { return !p.NeedFactor }),
 		Executor:  executeCalcFactor,
 	}
 
@@ -81,8 +85,19 @@ func init() {
 	TaskUpdateHolidays = &Task{
 		Name:      "update_holidays",
 		DependsOn: []string{"update_gbbq"},
+		SkipIf:    skipIfPlan(func(p *WorkPlan) bool { return !p.NeedHolidays }),
 		Executor:  executeUpdateHolidays,
 		OnError:   ErrorModeSkip,
+	}
+}
+
+// skipIfPlan 仅在 Plan 存在且谓词判为 true 时跳过；Plan 为 nil（如 init 流程）时保持原行为。
+func skipIfPlan(predicate func(*WorkPlan) bool) SkipCondition {
+	return func(ctx context.Context, db database.DataRepository, args *TaskArgs) bool {
+		if args.Plan == nil {
+			return false
+		}
+		return predicate(args.Plan)
 	}
 }
 
@@ -390,7 +405,20 @@ func prepareTdxData(ctx context.Context, latestDate time.Time, dataType string, 
 
 			validDates = append(validDates, date)
 		case 404:
-			fmt.Printf("🟡 %s 非交易日或数据尚未更新\n", dateStr)
+			var cal *TradingCalendar
+			if args.Plan != nil {
+				cal = args.Plan.Calendar
+			}
+			switch {
+			case cal != nil && cal.IsHoliday(date):
+				fmt.Printf("🎉 %s 为节假日，跳过\n", dateStr)
+			case cal != nil && cal.IsWeekend(date):
+				fmt.Printf("🌴 %s 为周末，跳过\n", dateStr)
+			case date.Equal(args.Today):
+				fmt.Printf("⏳ %s 数据尚未发布，请等待收盘后重试\n", dateStr)
+			default:
+				fmt.Printf("🟡 %s 数据尚未发布\n", dateStr)
+			}
 			continue
 		default:
 			if err != nil {


### PR DESCRIPTION
利用已入库的节假日 + 周末推导最近交易日：
- 数据库日线已覆盖最近交易日时跳过全部任务（含 gbbq/basic/factor）
- 今日为节假日/周末时输出明确休市提示
- 交易日下今日文件 404 时细化为"等待收盘后重试"