### PR TITLE
fix release image namespace

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,7 +167,7 @@ jobs:
         id: tags
         run: |
           VERSION="${GITHUB_REF_NAME}"
-          IMAGE="ghcr.io/jing2uo/tdx2db"
+          IMAGE="ghcr.io/${GITHUB_REPOSITORY,,}"
           TAGS="${IMAGE}:${VERSION}"
           if [[ "${GITHUB_REF_NAME}" != *-* ]]; then
             TAGS="${TAGS},${IMAGE}:latest"


### PR DESCRIPTION
## Summary
- Use the current GitHub repository owner/name when computing GHCR image tags
- Avoid pushing release images to a hardcoded namespace from forks

## Testing
- Not run; workflow-only change