### PR TITLE
docs: 同步 AGENTS.md/README 至当前 main 状态

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # PROJECT KNOWLEDGE BASE
 
-**Updated:** 2026-04-15
-**Branch:** feat/symbol-class
+**Updated:** 2026-05-02
+**Branch:** main
 
 ## OVERVIEW
-通达信(TDX) stock data importer — loads .day/.1/.05 files to DuckDB/ClickHouse, calculates preclose/turnover/market-value (basic), and 后复权因子 (hfq_factor).
+通达信(TDX) stock data importer — loads .day/.01/.5 files to DuckDB/ClickHouse, calculates preclose/turnover/market-value (basic), and 后复权因子 (hfq_factor). basic/factor 链路覆盖 stock + ETF (含 LOF/老封基/B股)。
 
 Current schema version: **v3.0** (`model.SchemaMajor=3, SchemaMinor=0`). The `_meta` table stores the schema version; init/cron check major version compatibility at startup.
 
@@ -20,7 +20,7 @@ Current schema version: **v3.0** (`model.SchemaMajor=3, SchemaMinor=0`). The `_m
 ├── model/      # Data models, table registry, view registry
 ├── tdx/        # TDX binary format parsing
 ├── utils/      # Utilities (cache, pipeline, CSV, download)
-├── workflow/   # Task execution framework (dependency resolution, DAG)
+├── workflow/   # Task execution framework (DAG, calendar, work plan)
 └── main.go     # Cobra CLI entry point
 ```
 
@@ -48,13 +48,16 @@ Current schema version: **v3.0** (`model.SchemaMajor=3, SchemaMinor=0`). The `_m
 | Init | func | cmd/init.go | Full import via workflow |
 | Cron | func | cmd/cron.go:11 | Incremental update via workflow |
 | Convert | func | cmd/convert.go | TDX to CSV conversion |
-| CalculateStockBasic | func | calc/basic.go:111 | Core basic calculation (preclose/turnover/MV) |
-| calculateFullHfq | func | calc/fq_quantaxis.go:97 | Core HFQ factor calculation |
-| buildXdxrDateSet | func | calc/fq_quantaxis.go:130 | Map gbbq dates → trading days for HFQ |
-| StockData | type | model/schema.go:5 | Raw daily OHLCV (renamed to KlineDay in v3) |
-| StockBasic | type | model/schema.go:33 | Calculated basic (preclose/turnover/MV) |
-| Factor | type | model/schema.go:27 | Adjust factor (hfq_factor) |
-| GbbqData | type | model/schema.go:45 | 股本变迁 data (category 1=除权, 2/3/5/7/8/9/10=股本变动) |
+| CalculateBasicDaily | func | calc/basic.go:115 | Core basic calculation (preclose/turnover/MV, stock+ETF) |
+| calculateFullHfq | func | calc/fq_quantaxis.go:86 | Core HFQ factor calculation |
+| BuildWorkPlan | func | workflow/plan.go:34 | 读 holidays + 各表最新日期，决定哪些任务要跑 |
+| TradingCalendar | type | workflow/calendar.go:5 | 节假日/周末判定 + 最近交易日查找 |
+| KlineDay | type | model/schema.go:14 | Raw daily OHLCV |
+| BasicDaily | type | model/schema.go:49 | Calculated basic (preclose/turnover/MV, stock+ETF) |
+| Factor | type | model/schema.go:41 | Adjust factor (hfq_factor) |
+| GbbqData | type | model/schema.go:61 | 股本变迁 data (cat 1=除权, 11=ETF份额折算, 2/3/5/7/8/9/10=股本变动) |
+| ClassifyCode | func | model/classify.go:58 | symbol → stock/index/etf/block/unknown |
+| PriceScale | func | model/classify.go:89 | TDX 原始整数价格换算 (股票=100, ETF/B股=1000) |
 | SchemaFromStruct | func | model/tables.go:54 | Reflect-based table registration |
 
 ## CONVENTIONS
@@ -64,8 +67,8 @@ Current schema version: **v3.0** (`model.SchemaMajor=3, SchemaMinor=0`). The `_m
 - DuckDB: `duckdb://[path]`
 
 **Table naming:**
-- `raw_*` — raw imported data (raw_kline_daily, raw_kline_1min, raw_kline_5min, raw_stocks_basic, raw_adjust_factor, raw_gbbq, raw_symbol_class, etc.)
-- `v_*` — views (v_bfq_daily, v_qfq_daily, v_hfq_daily)
+- `raw_*` — raw imported data (raw_kline_daily, raw_kline_1min, raw_kline_5min, raw_basic_daily, raw_adjust_factor, raw_gbbq, raw_symbol_class, raw_holidays)
+- `v_*` — views (v_bfq_daily, v_qfq_daily, v_hfq_daily) — 通过 `raw_symbol_class` 过滤，仅保留 stock + etf
 - `_meta` — schema version metadata (key/value store)
 
 **Table registration:**
@@ -81,8 +84,12 @@ Current schema version: **v3.0** (`model.SchemaMajor=3, SchemaMinor=0`). The `_m
 **Symbol classification (model/classify.go):**
 - `ClassifyCode(symbol) → stock/index/etf/block/unknown`
 - Rules match by (market, numeric prefix) — longest prefix wins
-- basic/factor calculation uses `GetSymbolsByClass("stock")` — no index/ETF in calc output
-- Class `unknown` includes: 可转债 (sh11xxxx, sz12xxxx, sz13xxxx), 封闭式基金 (sh50xxxx), 国债 (sh24xxxx), etc.
+- basic/factor calculation uses `GetSymbolsByClass("stock", "etf")` — index/block 仍排除在 calc 输出之外
+- 复权视图 (`v_*fq_daily`) 通过 `raw_symbol_class` 过滤，仅保留 stock + etf
+- B 股 (sh900/sz20) 归为 stock；ETF/LOF 归为 etf
+- `PriceScale(symbol)`：股票/指数/板块 价格单位 0.01 元(=100)，ETF/LOF/B股 0.001 元(=1000)
+- `SymbolFromCode(code)`：6 位裸数字反查市场前缀（仅考虑 stock/etf）
+- Class `unknown` 包括：可转债 (sh11xxxx, sz12xxxx, sz13xxxx), 国债 (sh24xxxx) 等
 
 **Schema versioning (cmd/schema_version.go):**
 - `model.SchemaMajor` / `model.SchemaMinor` define current version
@@ -93,6 +100,7 @@ Current schema version: **v3.0** (`model.SchemaMajor=3, SchemaMinor=0`). The `_m
 
 **GbbqData categories:**
 - Category 1: 除权除息 (dividends/bonus shares) — C1=分红, C2=配股, C3=送转股, C4=配股价
+- Category 11: ETF/LOF 份额折算 — C3=折算系数 (拆分日 PreClose 需除以该系数；多次折算同日累乘)
 - Category 2/3/5/7/8/9/10: 股本变动 — C1=变动前流通, C2=变动前总, C3=变动后流通, C4=变动后总
 - Stock units in gbbq are 万股 (×10000 = actual shares)
 
@@ -109,27 +117,29 @@ Current schema version: **v3.0** (`model.SchemaMajor=3, SchemaMinor=0`). The `_m
 
 ## CALCULATION LOGIC
 
-### calc/basic.go — CalculateStockBasic
-Input: `[]KlineDay` (raw daily) + `[]GbbqData` → Output: `[]StockBasic`
+### calc/basic.go — CalculateBasicDaily
+Input: `[]KlineDay` (raw daily) + `[]GbbqData` → Output: `[]*BasicDaily`
 
-1. **xdxr date mapping** (category=1): gbbq date → trading day via `sort.Search` (handles non-trading days)
-2. **Shares tracking** (category 2/3/5/7/8/9/10): maintains running float/total share counts
-3. **Initial share backfill**: if first gbbq share record is after IPO date, uses its C1/C2 (pre-change values) to backfill the gap
-4. **Per-day**: preclose (adjusted for xdxr), change_pct, amplitude, turnover (vol/float_shares), floatmv, totalmv
+1. **xdxr date mapping** (category=1, 11): gbbq date → KlineDay 索引 via `sort.Search` (handles non-trading days)
+2. **ETF cat=11 split**: `mergeSplitFromGbbq` 累乘 Splitc3，PreClose 末尾再除一次
+3. **Shares tracking** (category 2/3/5/7/8/9/10): maintains running float/total share counts (ETF 一般无此类记录)
+4. **Initial share backfill**: if first gbbq share record is after IPO date, uses its C1/C2 (pre-change values) to backfill the gap
+5. **Per-day**: preclose (adjusted for xdxr/split), change_pct, amplitude, turnover (vol/float_shares), floatmv, totalmv
 
-**PreClose formula** (with xdxr):
+**PreClose formula** (with xdxr + split):
 ```
-preclose = (prevClose×10 - 分红 + 配股×配股价) / (10 + 配股 + 送转股)
+preclose = ((prevClose×10 - 分红 + 配股×配股价) / (10 + 配股 + 送转股)) / Splitc3
 ```
+Splitc3 默认 1（无 cat=11）；cat=1 与 cat=11 同日时两者都生效。
 
 ### calc/fq_quantaxis.go — calculateFullHfq
-Input: `[]StockBasic` + `[]GbbqData` → Output: `[]Factor`
+Input: `[]BasicDaily` + `[]GbbqData` → Output: `[]Factor`
 
-1. **buildXdxrDateSet**: maps category=1 gbbq dates to trading days via `sort.Search` (same logic as basic.go)
+1. 直接消费 BasicDaily 中已计算好的 PreClose（不再单独 buildXdxrDateSet）
 2. **Factor accumulation**: starts at 1.0, on xdxr days: `hfq *= prevClose / preclose`
 3. Factor only changes when ratio ≠ 1.0 (uses 1e-9 tolerance)
 
-**Critical invariant**: basic.go and fq_quantaxis.go MUST use the same date mapping logic (gbbq date → trading day). Both use `sort.Search` to find first trading day ≥ gbbq date.
+**Critical invariant**: basic.go 是 PreClose 唯一计算源。fq_quantaxis.go 直接读 BasicDaily.PreClose，所以 basic.go 的日期映射 + cat=1/cat=11 处理是单一事实源，不需要在 fq 里重复。
 
 ## ANTI-PATTERNS (THIS PROJECT)
 
@@ -143,23 +153,25 @@ Input: `[]StockBasic` + `[]GbbqData` → Output: `[]Factor`
 **NEVER:**
 - Commit `tdx/embed/datatool` to git — downloaded at build time
 - Import `_ "github.com/duckdb/duckdb-go/v2"` outside init package — register driver early
-- Break the date mapping consistency between basic.go and fq_quantaxis.go
+- 在 fq_quantaxis 里再单独做 xdxr 日期映射 — 必须复用 basic.go 写出的 PreClose
 - Put version-check logic in the DB layer — DB only does Read/Write; judgment stays in cmd/
 
 ## UNIQUE STYLES
 
 **Task-based workflow (workflow/):**
-- `TaskExecutor` manages task execution with dependency resolution (DAG topological sort)
-- Tasks defined in `workflow/tasks.go` with explicit `DependsOn` arrays
+- `TaskExecutor` (engine.go) manages 任务执行 + DAG 拓扑排序
+- `WorkPlan` (plan.go) 在任务图启动前汇总日历 + 各表最新日期，决定 NeedDaily/NeedGbbq/NeedBasic/NeedFactor/NeedHolidays；任务的 `SkipIf` 只读 plan，不再各自查询数据库
+- `TradingCalendar` (calendar.go) 用 raw_holidays + 周末规则识别交易日，下载日线/分时遇到 404 时区分"节假日跳过"/"数据未发布"
+- Tasks defined in `workflow/tasks.go` with explicit `DependsOn`
 - Parallel execution of tasks with no dependencies
 - Optional tasks via `SkipIf` condition (e.g., `--minline`)
 - Error modes: `ErrorModeStop` (default) vs `ErrorModeSkip`
 
 **Incremental update logic:**
-- `cron` command uses workflow tasks with dependency: `update_daily → update_gbbq → calc_basic → calc_factor`
-- `calc_basic` and `calc_factor` run in **full recalculation mode** (truncate + reimport)
-- Each update task checks latest date → fetches delta from TDX
-- Supports 1min/5min incremental import (optional tasks)
+- `cron` command 先 `BuildWorkPlan(db, today)` → 全 `Skip` 则直接退出，否则跑 DAG: `update_daily → update_gbbq → calc_basic → calc_factor`，并行 `update_holidays`
+- raw_holidays 为空（首次/旧库）时 plan 强制走全流程，让 holidays 自行写入
+- `calc_basic` 和 `calc_factor` 永远 truncate + 重算（依赖完整历史）
+- 1min/5min 增量导入由 `--minline` 控制（可选任务）
 
 **CSV pipeline pattern:**
 - All calculation exports use `utils.Pipeline[I,O]` for concurrent per-symbol processing
@@ -194,5 +206,8 @@ tdx2db init --dburi 'clickhouse://localhost' --dayfiledir /path/to/vipdoc/
 - 复权因子算法 based on QUANTAXIS — verify before modifying
 - 分时数据无历史 — need to backfill manually
 - Symbol code changes not handled (历史记录不更新)
-- Indices (sh000xxx, sz399xxx, sh880/881xxx) have no float shares → turnover/floatmv = 0, this is expected
+- 指数/板块 (sh000xxx, sz399xxx, sh880/881xxx) 不在 calc 输出范围内（GetSymbolsByClass 只取 stock + etf）
+- ETF/LOF/B股 K线价格按 0.001 元解析 (`PriceScale`)，否则有 10x 偏差；新增品种前缀时务必检查
+- ETF 拆分日 (cat=11) PreClose 必须除以 Splitc3，否则当天涨跌幅会异常
 - `raw_symbol_class` is rebuilt from `raw_kline_daily` on each daily import — adding classification rules retroactively will auto-classify on next import
+- holidays 来自 gbbq.zip 内嵌的 zhb.zip (needini.dat)，不再依赖 tdxhome 安装目录

--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ raw\_ 前缀的表名用于存储基础数据，v\_ 前缀的表名是视图。
 | `raw_kline_1min`        | 1 分钟 K 线                   |
 | `raw_kline_5min`        | 5 分钟 K 线                   |
 | `raw_kline_daily`       | 日线数据 (股票/指数/ETF/板块) |
-| `raw_stocks_basic`      | 股票前收盘价、换手率与市值    |
+| `raw_basic_daily`       | 股票/ETF 前收盘价、换手率与市值 |
 | `raw_symbol_class`      | 品种分类 (stock/index/etf/等) |
-| `v_bfq_daily`           | 不复权日线，包含 stocks_basic |
+| `v_bfq_daily`           | 不复权日线，包含 basic_daily  |
 | `v_qfq_daily`           | 前复权日线数据                |
 | `v_hfq_daily`           | 后复权日线数据                |
 

--- a/calc/AGENTS.md
+++ b/calc/AGENTS.md
@@ -1,80 +1,82 @@
 # FINANCIAL CALCULATIONS
 
-**Purpose:** Calculate stock basic indicators (preclose, turnover, market value) and 后复权因子 (HFQ factor)
+**Purpose:** Calculate basic indicators (preclose, turnover, market value) and 后复权因子 (HFQ factor)，覆盖 stock + ETF/LOF/B股
 
 ## STRUCTURE
 ```
 ./calc/
-├── basic.go              # StockBasic calculation (preclose, turnover, MV)
-├── fq_quantaxis.go       # HFQ factor calculation (QUANTAXIS-based)
+├── basic.go              # BasicDaily calculation (preclose, turnover, MV)
+├── fq_quantaxis.go       # HFQ factor (QUANTAXIS-based, 直接消费 BasicDaily.PreClose)
 └── fq_quantaxis_test.go  # Factor calculation tests
 ```
 
 ## WHERE TO LOOK
 | Task | File | Notes |
 |------|------|-------|
-| Modify preclose formula | basic.go:265 | `calculatePreClosePrice()` |
-| Modify turnover/MV | basic.go:210-221 | Per-day loop in `CalculateStockBasic()` |
-| Modify share backfill | basic.go:161-178 | Initial float/total share logic |
-| Modify HFQ factor | fq_quantaxis.go:97 | `calculateFullHfq()` |
-| Modify xdxr date mapping | fq_quantaxis.go:130 | `buildXdxrDateSet()` |
+| Modify preclose formula | basic.go:298 | `calculatePreClosePrice()` (含 Splitc3) |
+| Modify turnover/MV | basic.go:228-241 | Per-day loop in `CalculateBasicDaily()` |
+| Modify share backfill | basic.go:179-197 | Initial float/total share logic |
+| ETF cat=11 split | basic.go:286 | `mergeSplitFromGbbq()` |
+| Modify HFQ factor | fq_quantaxis.go:86 | `calculateFullHfq()` |
 
 ## SHARED TYPES
-- `GbbqIndex` (basic.go:21): `map[string][]GbbqData` — per-symbol gbbq lookup, built once, shared by basic and factor
-- `xdxrInfo` (basic.go:14): accumulated 分红/配股/送转股 for a single xdxr event
-- `BasicContext` / `FactorContext`: hold DB + GbbqIndex for pipeline processing
+- `GbbqIndex` (basic.go:25): `map[string][]GbbqData` — per-symbol gbbq lookup
+- `xdxrInfo` (basic.go:15): 累积 分红/配股/送转股 + Splitc3 (cat=11 折算系数)
+- `BasicContext` / `FactorContext`: hold DB (+ GbbqIndex for basic) for pipeline processing
 
 ## DATA FLOW
 
 ```
 DB: raw_kline_daily + raw_gbbq
         │
-        ├──► calc/basic.go ──► raw_stocks_basic (preclose, turnover, floatmv, totalmv)
-        │
-        └──► calc/fq_quantaxis.go ──► raw_adjust_factor (hfq_factor)
-                (reads raw_stocks_basic for preclose)
+        └──► calc/basic.go (CalculateBasicDaily)
+                 │
+                 └──► raw_basic_daily (preclose, turnover, floatmv, totalmv) [stock + etf]
+                        │
+                        └──► calc/fq_quantaxis.go (calculateFullHfq)
+                                │
+                                └──► raw_adjust_factor (hfq_factor)
 ```
 
-Task dependency: `calc_basic` runs before `calc_factor` (factor needs preclose from basic).
+Task dependency: `calc_basic` runs before `calc_factor` (factor 直接读 basic.PreClose)。
+Symbol filter: `GetSymbolsByClass(stock, etf)` —— index/block 不参与计算。
 
 ## KEY ALGORITHMS
 
-### PreClose (basic.go:265)
+### PreClose (basic.go:298)
 ```
-preclose = (prevClose×10 - 分红 + 配股×配股价) / (10 + 配股 + 送转股)
+preclose = ((prevClose×10 - 分红 + 配股×配股价) / (10 + 配股 + 送转股)) / Splitc3
 ```
-When no xdxr event: `preclose = prevClose`
+- 无 xdxr/split：`preclose = prevClose`
+- Splitc3 来自 cat=11，多次同日折算累乘
 
-### HFQ Factor (fq_quantaxis.go:97)
+### HFQ Factor (fq_quantaxis.go:86)
 - Starts at 1.0 on day 1
-- On xdxr days: `hfq *= prevClose / preclose` (ratio captures the adjustment)
+- 通过 `prevClose / basic.PreClose` 检测除权日；ratio ≠ 1.0 时 `hfq *= ratio`
 - Factor only changes when `|ratio - 1.0| > 1e-9`
+- 不再独立维护 xdxr 日期集合 —— PreClose 已经把所有除权信息带进来
 
-### Gbbq Date → Trading Day Mapping
-Both basic.go and fq_quantaxis.go use `sort.Search` to map gbbq dates to the first trading day >= gbbq date. This handles gbbq events on weekends/holidays.
-
-```go
-idx := sort.Search(len(data), func(i int) bool {
-    return !data[i].Date.Before(gbbqDate)
-})
-```
+### Gbbq Date → KlineDay Index Mapping (basic.go:136)
+`findIdx`：先查 dateMap (精确匹配)，否则用 `sort.Search` 落到下一交易日。处理 gbbq 事件落在周末/假期的情况。
 
 ### Gbbq Categories
 | Category | Meaning | Fields used |
 |----------|---------|-------------|
 | 1 | 除权除息 | C1=分红, C2=配股, C3=送转股, C4=配股价 |
+| 11 | ETF/LOF 份额折算 | C3=折算系数 (PreClose 除以它) |
 | 2,3,5,7,8,9,10 | 股本变动 | C1=变前流通, C2=变前总股本, C3=变后流通, C4=变后总股本 |
 
-### Share Backfill (basic.go:161-178)
+### Share Backfill (basic.go:179-197)
 If the first gbbq share record date > IPO date, uses its C1/C2 (pre-change values) to backfill float/total shares for the gap period. Fallback chain: first.C1 → first.C3 → scan for first record with C3 > 0.
 
 ## ANTI-PATTERNS
 
 **DO NOT:**
-- Use raw gbbq dates to match against trading days — always map via `sort.Search`
-- Break date mapping consistency between basic.go and fq_quantaxis.go
+- Use raw gbbq dates to match against trading days — always go through `findIdx` / `sort.Search`
+- 在 fq_quantaxis 里再做一遍 xdxr 日期映射 —— 单一事实源在 basic.go 写出的 PreClose
 - Assume gbbq dates are always trading days — weekends/holidays are common
-- Modify preclose formula without understanding 除权除息 semantics
+- Modify preclose formula without understanding 除权除息 + cat=11 折算 semantics
+- 忘记 cat=11 处理 —— ETF 拆分日不除以 Splitc3 会让当天涨跌幅看起来像异常暴跌
 
 **NEVER:**
 - Change factor calculation to incremental — full recalc is intentional (factor depends on entire history)
@@ -87,3 +89,5 @@ If the first gbbq share record date > IPO date, uses its C1/C2 (pre-change value
 **Pipeline concurrency:** Both exports use `utils.Pipeline` to process symbols concurrently. Each symbol is independent.
 
 **Units:** gbbq share values are in 万股 (×10000 = actual shares). Turnover = volume / (float_shares × 10000).
+
+**ETF 一般无 cat 2/3/5/7/8/9/10 记录**，因此 turnover/floatmv/totalmv 通常为 0；这是预期行为。

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -53,11 +53,12 @@
 **cron command flow (cmd/cron.go):**
 1. Create DB + Connect + InitSchema
 2. `checkSchemaVersion()` — reject if version missing or incompatible
-3. Run `GetUpdateTaskNames()` → DAG execution:
+3. `workflow.BuildWorkPlan(db, today)` — 读 raw_holidays + 各表最新日期，决定哪些任务要跑；全 Skip 则直接退出 (打印 plan.Reason)
+4. Run `GetUpdateTaskNames()` → DAG execution（任务用 plan.NeedXxx 通过 SkipIf 短路）：
    - `update_daily` → `update_gbbq` → `calc_basic` → `calc_factor`
-   - Optional: `update_1min`, `update_5min` (via --minline)
    - `update_holidays` 依赖 `update_gbbq`，从 gbbq.zip 内嵌的 zhb.zip 读取 needini.dat
-4. calc_basic and calc_factor run full recalculation (truncate + reimport)
+   - Optional: `update_1min`, `update_5min` (via --minline)
+5. calc_basic and calc_factor run full recalculation (truncate + reimport)
 
 **convert command:**
 - Types: `day`, `1min`, `5min`, `tic4`, `day4`

--- a/database/AGENTS.md
+++ b/database/AGENTS.md
@@ -40,10 +40,11 @@
 - `Query()` - Generic query with conditions map
 - `QueryKlineDaily()` - Date range filtered OHLCV data
 - `GetLatestDate()` - Used by cron for incremental updates
-- `GetSymbolsByClass()` - Symbols filtered by class (stock/index/etf/block/unknown)
+- `GetSymbolsByClass(classes ...)` - Symbols filtered by class (calc 端传 stock + etf)
 - `RebuildSymbolClass()` - Rebuild symbol_class table from raw_kline_daily
-- `GetBasicsBySymbol()` - StockBasic data for factor calculation
+- `GetBasicsBySymbol()` - BasicDaily data (含 PreClose) for factor calculation
 - `GetGbbq()` - All gbbq records (loaded once, indexed in calc)
+- `GetHolidays()` - 全量节假日 (workflow.BuildWorkPlan 启动时读取)
 
 **CH import (clickhouse/dml.go):**
 - HTTP POST to `/` endpoint
@@ -74,8 +75,8 @@
 ## NOTES
 
 **Table naming:**
-- `raw_*` - Imported data tables (raw_kline_daily, raw_stocks_basic, raw_adjust_factor, raw_gbbq, raw_symbol_class, etc.)
-- `v_*` - Views (v_bfq_daily, v_qfq_daily, v_hfq_daily)
+- `raw_*` - Imported data tables (raw_kline_daily, raw_basic_daily, raw_adjust_factor, raw_gbbq, raw_symbol_class, raw_holidays, raw_kline_1min, raw_kline_5min)
+- `v_*` - Views (v_bfq_daily, v_qfq_daily, v_hfq_daily) - join `raw_symbol_class` 过滤 `class IN ('stock','etf')`
 - `_meta` - Schema version and metadata (key/value)
 - Tables auto-registered via `model.SchemaFromStruct()`, views via `model.DefineView()`
 - View implementations are driver-specific (registered in ddl.go via `registerViews()`)

--- a/model/AGENTS.md
+++ b/model/AGENTS.md
@@ -5,8 +5,8 @@
 ## STRUCTURE
 ```
 ./model/
-├── classify.go  # Symbol classification (ClassifyCode → stock/index/etf/block/unknown)
-├── schema.go    # Data structs (KlineDay, KlineMin, StockBasic, Factor, GbbqData, Meta, etc.)
+├── classify.go  # Symbol classification + PriceScale + SymbolFromCode
+├── schema.go    # Data structs (KlineDay, KlineMin, BasicDaily, Factor, GbbqData, Meta, Holiday, SymbolClass)
 ├── tables.go    # Table metadata registry (SchemaFromStruct)
 └── views.go     # View ID registry (DefineView)
 ```
@@ -26,11 +26,11 @@
 | KlineDay | raw_kline_daily | Raw OHLCV + date |
 | KlineMin | raw_kline_1min / raw_kline_5min | Minute OHLCV + datetime |
 | SymbolClass | raw_symbol_class | Symbol → class mapping (stock/index/etf/block/unknown) |
-| StockBasic | raw_stocks_basic | Calculated: preclose, change_pct, amplitude, turnover, floatmv, totalmv |
+| BasicDaily | raw_basic_daily | Calculated: preclose, change_pct, amplitude, turnover, floatmv, totalmv (覆盖 stock + ETF) |
 | Factor | raw_adjust_factor | HFQ factor per symbol per date |
-| GbbqData | raw_gbbq | 股本变迁: category + C1-C4 |
+| GbbqData | raw_gbbq | 股本变迁: category + C1-C4 (cat=1 除权 / 11 ETF 折算 / 2-10 股本变动) |
 | Meta | _meta | Key-value metadata (schema version, etc.) |
-| Holiday | raw_holidays | Holiday dates |
+| Holiday | raw_holidays | Holiday dates (来自 gbbq.zip 内嵌 zhb.zip 的 needini.dat) |
 
 ## CONVENTIONS
 
@@ -50,6 +50,12 @@
 - `DefineView()` registers view ID into global `viewRegistry`
 - View SQL is driver-specific (implemented in database/*/ddl.go)
 - Three views: v_bfq_daily (不复权), v_qfq_daily (前复权), v_hfq_daily (后复权)
+- 视图通过 join `raw_symbol_class` 过滤 `class IN ('stock','etf')`
+
+**Classification helpers (classify.go):**
+- `ClassifyCode(symbol)` → stock/index/etf/block/unknown，按 (market, prefix) 最长前缀匹配
+- `PriceScale(symbol)` → 100 (股票/指数/板块) 或 1000 (ETF/LOF/B股) 用于解析 TDX 原始整数价格
+- `SymbolFromCode(code)` → 6 位裸数字反查 "shXXXXXX"/"szXXXXXX"，仅考虑 stock/etf 避免 "000" 歧义
 
 ## ANTI-PATTERNS
 

--- a/tdx/AGENTS.md
+++ b/tdx/AGENTS.md
@@ -1,15 +1,18 @@
 # TDX DATA PARSING
 
-**Purpose:** Parse 通达信(TDX) binary format files (.day, .1, .05) 与假期日历
+**Purpose:** Parse 通达信(TDX) binary format files (.day, .01, .5) 与假期日历
 
 ## STRUCTURE
 ```
 ./tdx/
-├── kline.go       # K-line parsing (.day, .1, .05)
+├── kline.go       # K-line parsing (.day, .1, .5)
+├── kline_test.go
+├── merge.go       # native day merge (跨平台合并 vipdoc 输出)
+├── merge_test.go
 ├── gbbq.go        # 股本变迁 parsing
-├── holidays.go    # 交易日历解析
+├── holidays.go    # 交易日历解析 (zhb.zip → needini.dat)
 ├── gbbq_var.go    # TDX datatool variable definitions
-├── datatool.go    # Embedded datatool interface
+├── datatool.go    # Embedded datatool interface (Linux only)
 └── embed/         # Embedded TDX datatool binary
 ```
 
@@ -33,7 +36,8 @@
 - Min: `year = date/2048 + 2004`, `month = (date%2048)/100`, `day = (date%2048)%100`
 
 **Price conversion:**
-- All prices divide by 100.0 (raw * 100 = actual price)
+- 价格刻度由 `model.PriceScale(symbol)` 给出：股票/指数/板块 = 100，ETF/LOF/B股 = 1000
+- 解析每条记录时按 symbol 取 scale，再 `float64(raw) / scale`
 - Amount stored as float32 bits
 
 **Pipeline usage:**
@@ -57,8 +61,8 @@
 
 **File suffixes:**
 - `.day` - Daily K-line data
-- `.1` - 1-minute K-line
-- `.05` - 5-minute K-line
+- `.01` - 1-minute K-line
+- `.5` - 5-minute K-line
 
 **Symbol extraction:**
 - Symbol = filename without suffix (e.g., `sh000001.day` → `sh000001`)

--- a/workflow/AGENTS.md
+++ b/workflow/AGENTS.md
@@ -1,20 +1,24 @@
 # WORKFLOW EXECUTION FRAMEWORK
 
-**Purpose:** Task execution framework with dependency resolution (DAG)
+**Purpose:** Task execution framework (DAG) + 交易日历 + 任务前置规划 (WorkPlan)
 
 ## STRUCTURE
 ```
 ./workflow/
-├── engine.go   # TaskExecutor, Task, TaskArgs, TaskResult
-└── tasks.go    # Task definitions (init/update modes)
+├── engine.go    # TaskExecutor, Task, TaskArgs (含 Plan), TaskResult
+├── tasks.go     # Task definitions (init/update modes) + executors
+├── plan.go      # WorkPlan + BuildWorkPlan (cron 启动前的全局规划)
+└── calendar.go  # TradingCalendar (节假日/周末/最近交易日)
 ```
 
 ## WHERE TO LOOK
 | Task | File | Notes |
 |------|------|-------|
 | Add new task | tasks.go | Define task with dependencies |
-| Run specific tasks | task.go | Use TaskExecutor with task names |
+| Run specific tasks | engine.go | Use TaskExecutor.Run with task names |
 | Modify task logic | tasks.go | Update executor function |
+| 调整 cron 跑哪些任务 | plan.go | BuildWorkPlan / NeedXxx 推导 |
+| 节假日判定 | calendar.go | TradingCalendar |
 
 ## CONVENTIONS
 
@@ -42,12 +46,24 @@ TaskUpdate1Min = &Task{
     Name:      "update_1min",
     DependsOn: []string{},
     SkipIf: func(ctx, db, args) bool {
-        return !strings.Contains(args.Minline, "1")
+        need1Min, _, _ := ParseMinline(args.Minline)
+        return !need1Min
     },
     Executor: executeUpdate1Min,
     OnError: ErrorModeSkip,
 }
 ```
+
+**Plan-driven SkipIf（cron 主链路）：**
+```go
+TaskCalcBasic = &Task{
+    Name: "calc_basic",
+    DependsOn: []string{"update_daily", "update_gbbq"},
+    SkipIf: skipIfPlan(func(p *WorkPlan) bool { return !p.NeedBasic }),
+    Executor: executeCalcBasic,
+}
+```
+`skipIfPlan` 在 `args.Plan == nil` (init 流程) 时不跳过，保持原行为。
 
 **Common abstraction:**
 - `executeDailyImport()` - Shared logic for daily data conversion + import
@@ -59,6 +75,12 @@ TaskUpdate1Min = &Task{
 - `TempDir`, `VipdocDir` - Temp directories
 - `DayFileDir` - User-provided TDX data directory (for init)
 - `Today` - Current date for incremental updates
+- `Plan *WorkPlan` - cron 由 `BuildWorkPlan` 注入；init 留空，`skipIfPlan` 自动放行所有任务
+
+**WorkPlan / TradingCalendar：**
+- `BuildWorkPlan(db, today)`：先读 `raw_holidays`，空表（首次/旧库）→ 强制全流程跑；否则用 `TradingCalendar.LastTradingDayOnOrBefore(today)` 与各表最新日期比较，标记 `NeedDaily/NeedGbbq/NeedBasic/NeedFactor/NeedHolidays`
+- `plan.AnyNeeded() == false` → cron 直接退出
+- `Calendar` 还会回流到 `prepareTdxData`，下载日线 404 时区分"节假日跳过 🎉"/"周末 🌴"/"未发布 ⏳"
 
 ## ANTI-PATTERNS
 
@@ -102,12 +124,18 @@ executor.Run(ctx, workflow.GetInitTaskNames(), args)
 
 **Usage from cmd/cron.go:**
 ```go
+plan, err := workflow.BuildWorkPlan(db, GetToday())
+if !plan.AnyNeeded() {
+    fmt.Println(plan.Reason)
+    return nil
+}
 executor := workflow.NewTaskExecutor(db, workflow.GetRegisteredTasks())
 args := &workflow.TaskArgs{
     Minline:   minline,
     TempDir:   TempDir,
     VipdocDir: VipdocDir,
     Today:     GetToday(),
+    Plan:      plan,
 }
 executor.Run(ctx, workflow.GetUpdateTaskNames(), args)
 ```


### PR DESCRIPTION
## Summary
- 全量 sweep AGENTS.md 与 README 表清单, 反映 2026-04-15 之后的代码变化, 不动任何源码
- 重点: 表/类型/函数重命名 (raw_basic_daily / BasicDaily / CalculateBasicDaily)、basic+factor 覆盖 ETF、cat=11 份额折算、PriceScale、新 workflow plan/calendar、update_holidays、复权视图过滤 class IN ('stock','etf')
- 顺手修正 tdx 文档里过时的分时后缀 .1/.05 → .01/.5

## Test plan
- [ ] 阅读 root + 各包 AGENTS.md, 确认与当前代码一致
- [ ] 检查 README 表清单中的 raw_basic_daily 与代码 model.TableBasicDaily 对齐

🤖 Generated with [Claude Code](https://claude.com/claude-code)