### PR TITLE
refactor: 砍 5min 入库, 暴露 ImportCSV

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ Current schema version: **v3.0** (`model.SchemaMajor=3, SchemaMinor=0`). The `_m
 - DuckDB: `duckdb://[path]`
 
 **Table naming:**
-- `raw_*` — raw imported data (raw_kline_daily, raw_kline_1min, raw_kline_5min, raw_basic_daily, raw_adjust_factor, raw_gbbq, raw_symbol_class, raw_holidays)
+- `raw_*` — raw imported data (raw_kline_daily, raw_kline_1min, raw_basic_daily, raw_adjust_factor, raw_gbbq, raw_symbol_class, raw_holidays)
 - `v_*` — views (v_bfq_daily, v_qfq_daily, v_hfq_daily) — 通过 `raw_symbol_class` 过滤，仅保留 stock + etf
 - `_meta` — schema version metadata (key/value store)
 
@@ -77,7 +77,7 @@ Current schema version: **v3.0** (`model.SchemaMajor=3, SchemaMinor=0`). The `_m
 - Use `model.Table*` / `model.MetaTable` constants for table references (never hardcode table names)
 
 **TDX file collection (cmd/common.go):**
-- All .day/.01/.5 files collected by suffix, filtered only by `^(sh|sz|bj)\d+$` regex
+- All .day/.01 files collected by suffix, filtered only by `^(sh|sz|bj)\d+$` regex
 - No prefix whitelist — full ingest of everything TDX provides
 - Symbol classification via `raw_symbol_class` table (rebuilt after each daily import)
 
@@ -164,14 +164,14 @@ Input: `[]BasicDaily` + `[]GbbqData` → Output: `[]Factor`
 - `TradingCalendar` (calendar.go) 用 raw_holidays + 周末规则识别交易日，下载日线/分时遇到 404 时区分"节假日跳过"/"数据未发布"
 - Tasks defined in `workflow/tasks.go` with explicit `DependsOn`
 - Parallel execution of tasks with no dependencies
-- Optional tasks via `SkipIf` condition (e.g., `--minline`)
+- Optional tasks via `SkipIf` condition (e.g., `--min`)
 - Error modes: `ErrorModeStop` (default) vs `ErrorModeSkip`
 
 **Incremental update logic:**
 - `cron` command 先 `BuildWorkPlan(db, today)` → 全 `Skip` 则直接退出，否则跑 DAG: `update_daily → update_gbbq → calc_basic → calc_factor`，并行 `update_holidays`
 - raw_holidays 为空（首次/旧库）时 plan 强制走全流程，让 holidays 自行写入
 - `calc_basic` 和 `calc_factor` 永远 truncate + 重算（依赖完整历史）
-- 1min/5min 增量导入由 `--minline` 控制（可选任务）
+- 1min 增量导入由 `--min` 控制（可选任务）
 
 **CSV pipeline pattern:**
 - All calculation exports use `utils.Pipeline[I,O]` for concurrent per-symbol processing

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ## 亮点
 
 - **增量更新**: 支持间隔数天后数据补全，维护简单
-- **分时数据**: 支持导入 1min 和 5min 分时数据
+- **分时数据**: 支持导入 1 分钟分时数据
 - **复权计算**: 自动计算前后复权因子，因子支持分时使用
 - **衍生指标**: 自动计算换手率和市值信息
 - **稳定可靠**: 基于通达信数据，不依赖收费或限流接口
@@ -118,11 +118,11 @@ tdx2db cron --dburi 'duckdb://tdx.db'    # ClickHouse schema 参考 init 部分
 
 ### 分时数据
 
-cron 命令支持 1min 和 5min 分时数据导入。
+cron 命令支持 1 分钟分时数据导入。
 
 ```bash
-# --minline 可选 1、5、1,5 ，分别表示只处理1分钟、只处理5分钟、两种都处理
-tdx2db cron --dburi 'duckdb://tdx.db' --minline 1,5
+# 加 --min 才会下载并导入 1 分钟分时
+tdx2db cron --dburi 'duckdb://tdx.db' --min
 ```
 
 **注意**
@@ -143,7 +143,6 @@ raw\_ 前缀的表名用于存储基础数据，v\_ 前缀的表名是视图。
 | `raw_gbbq`              | 股本变迁数据                  |
 | `raw_holidays`          | 假期日历                      |
 | `raw_kline_1min`        | 1 分钟 K 线                   |
-| `raw_kline_5min`        | 5 分钟 K 线                   |
 | `raw_kline_daily`       | 日线数据 (股票/指数/ETF/板块) |
 | `raw_basic_daily`       | 股票/ETF 前收盘价、换手率与市值 |
 | `raw_symbol_class`      | 品种分类 (stock/index/etf/等) |

--- a/cmd/AGENTS.md
+++ b/cmd/AGENTS.md
@@ -57,11 +57,11 @@
 4. Run `GetUpdateTaskNames()` → DAG execution（任务用 plan.NeedXxx 通过 SkipIf 短路）：
    - `update_daily` → `update_gbbq` → `calc_basic` → `calc_factor`
    - `update_holidays` 依赖 `update_gbbq`，从 gbbq.zip 内嵌的 zhb.zip 读取 needini.dat
-   - Optional: `update_1min`, `update_5min` (via --minline)
+   - Optional: `update_1min` (via --min)
 5. calc_basic and calc_factor run full recalculation (truncate + reimport)
 
 **convert command:**
-- Types: `day`, `1min`, `5min`, `tic4`, `day4`
+- Types: `day`, `1min`, `tic4`, `day4`
 - Input: directory or zip file
 - Output: CSV files
 - Standalone: no database connection needed
@@ -79,9 +79,6 @@
 - Add command without required flags validation
 
 ## NOTES
-
-**Flag validation:**
-- `--minline` only accepts: `1`, `5`, `1,5`, `5,1`
 
 **Error handling:**
 - Wrap errors with `%w` for error chain

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -24,12 +24,11 @@ const (
 	TicZip
 	DayZip
 	Min1FileDir
-	Min5FileDir
 )
 
 func isDirType(t InputSourceType) bool {
 	switch t {
-	case DayFileDir, Min1FileDir, Min5FileDir:
+	case DayFileDir, Min1FileDir:
 		return true
 	default:
 		return false
@@ -94,18 +93,6 @@ func Convert(ctx context.Context, opts ConvertOptions) error {
 
 		fmt.Printf("🔥 转换完成: %s\n", output)
 
-	case Min5FileDir:
-		fmt.Printf("📦 开始处理分时数据目录: %s\n", opts.InputPath)
-		output := filepath.Join(opts.OutputPath, "tdx2db_5min.csv")
-
-		fmt.Println("🐌 开始转换 5 分钟数据")
-		_, err := tdx.ConvertFilesToCSV(ctx, opts.InputPath, output, ".5")
-		if err != nil {
-			return fmt.Errorf("failed to convert 5min files: %w", err)
-		}
-
-		fmt.Printf("🔥 转换完成: %s\n", output)
-
 	case TicZip:
 		fmt.Printf("📦 开始处理四代 TIC 压缩文件: %s\n", opts.InputPath)
 
@@ -136,7 +123,6 @@ func Convert(ctx context.Context, opts ConvertOptions) error {
 		}
 
 		min1_output := filepath.Join(opts.OutputPath, fmt.Sprintf("%s_1min.csv", baseName))
-		min5_output := filepath.Join(opts.OutputPath, fmt.Sprintf("%s_5min.csv", baseName))
 
 		fmt.Printf("🐌 开始转换 1 分钟数据\n")
 		_, err := tdx.ConvertFilesToCSV(ctx, VipdocDir, min1_output, ".01")
@@ -144,22 +130,8 @@ func Convert(ctx context.Context, opts ConvertOptions) error {
 			return fmt.Errorf("failed to convert 1-minute files: %w", err)
 		}
 
-		// 检查取消
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		fmt.Printf("🐌 开始转换 5 分钟数据\n")
-		_, err = tdx.ConvertFilesToCSV(ctx, VipdocDir, min5_output, ".5")
-		if err != nil {
-			return fmt.Errorf("failed to convert 5-minute files: %w", err)
-		}
-
 		fmt.Printf("🔥 转换完成\n")
 		fmt.Printf("📊 1 分钟数据: %s\n", min1_output)
-		fmt.Printf("📊 5 分钟数据: %s\n", min5_output)
 
 	case DayZip:
 		fmt.Printf("📦 开始处理四代行情压缩文件: %s\n", opts.InputPath)

--- a/cmd/cron.go
+++ b/cmd/cron.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jing2uo/tdx2db/workflow"
 )
 
-func Cron(ctx context.Context, dbURI, minline string) error {
+func Cron(ctx context.Context, dbURI string, min bool) error {
 	db, err := database.NewDB(dbURI)
 	if err != nil {
 		return fmt.Errorf("failed to create database driver: %w", err)
@@ -48,7 +48,7 @@ func Cron(ctx context.Context, dbURI, minline string) error {
 	executor := workflow.NewTaskExecutor(db, workflow.GetRegisteredTasks())
 
 	args := &workflow.TaskArgs{
-		Minline:   minline,
+		Min:       min,
 		TempDir:   TempDir,
 		VipdocDir: VipdocDir,
 		Today:     today,

--- a/database/AGENTS.md
+++ b/database/AGENTS.md
@@ -75,7 +75,7 @@
 ## NOTES
 
 **Table naming:**
-- `raw_*` - Imported data tables (raw_kline_daily, raw_basic_daily, raw_adjust_factor, raw_gbbq, raw_symbol_class, raw_holidays, raw_kline_1min, raw_kline_5min)
+- `raw_*` - Imported data tables (raw_kline_daily, raw_basic_daily, raw_adjust_factor, raw_gbbq, raw_symbol_class, raw_holidays, raw_kline_1min)
 - `v_*` - Views (v_bfq_daily, v_qfq_daily, v_hfq_daily) - join `raw_symbol_class` 过滤 `class IN ('stock','etf')`
 - `_meta` - Schema version and metadata (key/value)
 - Tables auto-registered via `model.SchemaFromStruct()`, views via `model.DefineView()`

--- a/database/clickhouse/ddl.go
+++ b/database/clickhouse/ddl.go
@@ -72,6 +72,7 @@ func (d *ClickHouseDriver) createTableInternal(meta *model.TableMeta) error {
 }
 
 func (d *ClickHouseDriver) registerViews() {
+
 	// 不复权视图 (BFQ) — stock + etf
 	d.viewImpls[model.ViewDailyBFQ] = func() error {
 		query := fmt.Sprintf(`

--- a/database/clickhouse/dml.go
+++ b/database/clickhouse/dml.go
@@ -13,7 +13,7 @@ import (
 	"github.com/jing2uo/tdx2db/model"
 )
 
-func (d *ClickHouseDriver) importCSV(meta *model.TableMeta, filePath string) error {
+func (d *ClickHouseDriver) ImportCSV(meta *model.TableMeta, filePath string) error {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return err
@@ -75,33 +75,29 @@ func (d *ClickHouseDriver) TruncateTable(meta *model.TableMeta) error {
 }
 
 func (d *ClickHouseDriver) ImportKlineDaily(path string) error {
-	return d.importCSV(model.TableKlineDaily, path)
+	return d.ImportCSV(model.TableKlineDaily, path)
 }
 
 func (d *ClickHouseDriver) ImportKline1Min(path string) error {
-	return d.importCSV(model.TableKline1Min, path)
-}
-
-func (d *ClickHouseDriver) ImportKline5Min(path string) error {
-	return d.importCSV(model.TableKline5Min, path)
+	return d.ImportCSV(model.TableKline1Min, path)
 }
 
 func (d *ClickHouseDriver) ImportGBBQ(path string) error {
 	d.TruncateTable(model.TableGbbq)
-	return d.importCSV(model.TableGbbq, path)
+	return d.ImportCSV(model.TableGbbq, path)
 }
 
 func (d *ClickHouseDriver) ImportBasic(path string) error {
-	return d.importCSV(model.TableBasicDaily, path)
+	return d.ImportCSV(model.TableBasicDaily, path)
 }
 
 func (d *ClickHouseDriver) ImportAdjustFactors(path string) error {
-	return d.importCSV(model.TableAdjustFactor, path)
+	return d.ImportCSV(model.TableAdjustFactor, path)
 }
 
 func (d *ClickHouseDriver) ImportHolidays(path string) error {
 	d.TruncateTable(model.TableHoliday)
-	return d.importCSV(model.TableHoliday, path)
+	return d.ImportCSV(model.TableHoliday, path)
 }
 
 func (d *ClickHouseDriver) Query(table string, conditions map[string]interface{}, dest interface{}) error {

--- a/database/duckdb/dml.go
+++ b/database/duckdb/dml.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jing2uo/tdx2db/model"
 )
 
-func (d *DuckDBDriver) importCSV(meta *model.TableMeta, csvPath string) error {
+func (d *DuckDBDriver) ImportCSV(meta *model.TableMeta, csvPath string) error {
 	var colMaps []string
 	for _, col := range meta.Columns {
 		duckType := d.mapType(col.Type)
@@ -45,33 +45,29 @@ func (d *DuckDBDriver) TruncateTable(meta *model.TableMeta) error {
 }
 
 func (d *DuckDBDriver) ImportKlineDaily(path string) error {
-	return d.importCSV(model.TableKlineDaily, path)
+	return d.ImportCSV(model.TableKlineDaily, path)
 }
 
 func (d *DuckDBDriver) ImportKline1Min(path string) error {
-	return d.importCSV(model.TableKline1Min, path)
-}
-
-func (d *DuckDBDriver) ImportKline5Min(path string) error {
-	return d.importCSV(model.TableKline5Min, path)
+	return d.ImportCSV(model.TableKline1Min, path)
 }
 
 func (d *DuckDBDriver) ImportGBBQ(path string) error {
 	d.TruncateTable(model.TableGbbq)
-	return d.importCSV(model.TableGbbq, path)
+	return d.ImportCSV(model.TableGbbq, path)
 }
 
 func (d *DuckDBDriver) ImportBasic(path string) error {
-	return d.importCSV(model.TableBasicDaily, path)
+	return d.ImportCSV(model.TableBasicDaily, path)
 }
 
 func (d *DuckDBDriver) ImportAdjustFactors(path string) error {
-	return d.importCSV(model.TableAdjustFactor, path)
+	return d.ImportCSV(model.TableAdjustFactor, path)
 }
 
 func (d *DuckDBDriver) ImportHolidays(path string) error {
 	d.TruncateTable(model.TableHoliday)
-	return d.importCSV(model.TableHoliday, path)
+	return d.ImportCSV(model.TableHoliday, path)
 }
 
 func (d *DuckDBDriver) Query(table string, conditions map[string]interface{}, dest interface{}) error {

--- a/database/interface.go
+++ b/database/interface.go
@@ -15,9 +15,9 @@ type DataRepository interface {
 	ReadSchemaVersion() (string, error)
 	WriteSchemaVersion() error
 
+	ImportCSV(meta *model.TableMeta, csvPath string) error
 	ImportKlineDaily(csvPath string) error
 	ImportKline1Min(csvPath string) error
-	ImportKline5Min(csvPath string) error
 	ImportAdjustFactors(csvPath string) error
 	ImportGBBQ(csvPath string) error
 	ImportBasic(csvPath string) error

--- a/main.go
+++ b/main.go
@@ -20,19 +20,15 @@ Database URI:
   DuckDB:     duckdb://[path]`
 
 const dayFileInfo = "通达信日线文件目录"
-const minLineInfo = `导入分时数据（可选）
-  1    导入1分钟分时数据
-  5    导入5分钟分时数据
-  1,5  导入两种`
+const minInfo = "导入 1 分钟分时数据（可选）"
 
 const convertHelp = `
 
 Type & Input:
-  -t day   转换日线文件     -i 包含 .day 的目录
-  -t 1min  转换 1 分钟分时  -i 包含 .1 的目录
-  -t 5min  转换 5 分钟分时  -i 包含 .05 的目录
-  -t tic4  转换四代分笔     -i 四代 TIC 压缩文件
-  -t day4  转换四代日线     -i 四代行情压缩文件`
+  -t day   转换日线文件          -i 包含 .day 的目录
+  -t 1min  转换 1 分钟分时       -i 包含 .1 的目录
+  -t tic4  四代分笔转 1 分钟分时 -i 四代 TIC 压缩文件
+  -t day4  转换四代日线          -i 四代行情压缩文件`
 
 func main() {
 	// 创建可取消的 context
@@ -57,7 +53,7 @@ func main() {
 	var (
 		dbURI      string
 		dayFileDir string
-		minline    string
+		minEnable  bool
 
 		// Convert
 		inputType  string
@@ -78,16 +74,10 @@ func main() {
 	var cronCmd = &cobra.Command{
 		Use:   "cron",
 		Short: "Cron for update data and calc factor",
-		Example: `  tdx2db cron --dburi 'clickhouse://localhost' --minline 1,5
+		Example: `  tdx2db cron --dburi 'clickhouse://localhost' --min
   tdx2db cron --dburi 'duckdb://./tdx.db'` + dbURIHelp,
 		RunE: func(c *cobra.Command, args []string) error {
-			if c.Flags().Changed("minline") {
-				valid := map[string]bool{"1": true, "5": true, "1,5": true, "5,1": true}
-				if !valid[minline] {
-					return fmt.Errorf("--minline 仅支持 '1'、'5'、'1,5', 传入: %s", minline)
-				}
-			}
-			return cmd.Cron(ctx, dbURI, minline)
+			return cmd.Cron(ctx, dbURI, minEnable)
 		},
 	}
 
@@ -107,8 +97,6 @@ func main() {
 				opts.InputType = cmd.DayFileDir
 			case "1min":
 				opts.InputType = cmd.Min1FileDir
-			case "5min":
-				opts.InputType = cmd.Min5FileDir
 			case "tic4":
 				opts.InputType = cmd.TicZip
 			case "day4":
@@ -130,7 +118,7 @@ func main() {
 	// Cron Flags
 	cronCmd.Flags().StringVar(&dbURI, "dburi", "", dbURIInfo)
 	cronCmd.MarkFlagRequired("dburi")
-	cronCmd.Flags().StringVar(&minline, "minline", "", minLineInfo)
+	cronCmd.Flags().BoolVar(&minEnable, "min", false, minInfo)
 
 	// Convert Flags
 	convertCmd.Flags().StringVarP(&inputType, "type", "t", "", "转换类型")

--- a/model/AGENTS.md
+++ b/model/AGENTS.md
@@ -24,7 +24,7 @@
 | Struct | Table | Description |
 |--------|-------|-------------|
 | KlineDay | raw_kline_daily | Raw OHLCV + date |
-| KlineMin | raw_kline_1min / raw_kline_5min | Minute OHLCV + datetime |
+| KlineMin | raw_kline_1min | Minute OHLCV + datetime |
 | SymbolClass | raw_symbol_class | Symbol → class mapping (stock/index/etf/block/unknown) |
 | BasicDaily | raw_basic_daily | Calculated: preclose, change_pct, amplitude, turnover, floatmv, totalmv (覆盖 stock + ETF) |
 | Factor | raw_adjust_factor | HFQ factor per symbol per date |

--- a/model/schema.go
+++ b/model/schema.go
@@ -5,7 +5,7 @@ import "time"
 // SchemaMajor 表示数据库 schema 的主版本号。
 // 当发生破坏性变更（表重命名、字段语义变化等）时递增。
 // 已安装的数据库 major 版本与当前代码不匹配时，工具将拒绝操作并提示用户查看文档。
-const SchemaMajor = 3
+const SchemaMajor = 4
 
 // SchemaMinor 表示数据库 schema 的次版本号。
 // 当发生非破坏性变更（新增表、新增字段等）时递增。

--- a/model/tables.go
+++ b/model/tables.go
@@ -125,12 +125,6 @@ var TableKline1Min = SchemaFromStruct(
 	[]string{"symbol", "datetime"},
 )
 
-var TableKline5Min = SchemaFromStruct(
-	"raw_kline_5min",
-	KlineMin{},
-	[]string{"symbol", "datetime"},
-)
-
 var TableSymbolClass = SchemaFromStruct(
 	"raw_symbol_class",
 	SymbolClass{},

--- a/tdx/AGENTS.md
+++ b/tdx/AGENTS.md
@@ -1,11 +1,11 @@
 # TDX DATA PARSING
 
-**Purpose:** Parse 通达信(TDX) binary format files (.day, .01, .5) 与假期日历
+**Purpose:** Parse 通达信(TDX) binary format files (.day, .01) 与假期日历
 
 ## STRUCTURE
 ```
 ./tdx/
-├── kline.go       # K-line parsing (.day, .1, .5)
+├── kline.go       # K-line parsing (.day, .01)
 ├── kline_test.go
 ├── merge.go       # native day merge (跨平台合并 vipdoc 输出)
 ├── merge_test.go
@@ -62,7 +62,6 @@
 **File suffixes:**
 - `.day` - Daily K-line data
 - `.01` - 1-minute K-line
-- `.5` - 5-minute K-line
 
 **Symbol extraction:**
 - Symbol = filename without suffix (e.g., `sh000001.day` → `sh000001`)

--- a/tdx/kline.go
+++ b/tdx/kline.go
@@ -24,7 +24,7 @@ func ConvertFilesToCSV(ctx context.Context, inputDir string, outputFile string, 
 	switch suffix {
 	case ".day":
 		return runConversion[model.KlineDay](ctx, inputDir, outputFile, suffix, processDayFile)
-	case ".01", ".5":
+	case ".01":
 		return runConversion[model.KlineMin](ctx, inputDir, outputFile, suffix, processMinFile)
 	default:
 		return "", fmt.Errorf("unsupported suffix: %s", suffix)

--- a/workflow/AGENTS.md
+++ b/workflow/AGENTS.md
@@ -46,8 +46,7 @@ TaskUpdate1Min = &Task{
     Name:      "update_1min",
     DependsOn: []string{},
     SkipIf: func(ctx, db, args) bool {
-        need1Min, _, _ := ParseMinline(args.Minline)
-        return !need1Min
+        return !args.Min
     },
     Executor: executeUpdate1Min,
     OnError: ErrorModeSkip,
@@ -71,7 +70,7 @@ TaskCalcBasic = &Task{
 - `executeInitDaily()` - Uses user-provided directory, then calls `executeDailyImport()`
 
 **TaskArgs:**
-- `Minline` - "1", "5", "1,5"
+- `Min` - bool, 设为 true 时 cron 会跑 update_1min
 - `TempDir`, `VipdocDir` - Temp directories
 - `DayFileDir` - User-provided TDX data directory (for init)
 - `Today` - Current date for incremental updates
@@ -97,17 +96,17 @@ TaskCalcBasic = &Task{
 ## NOTES
 
 **Task chains:**
-- Update mode: `update_daily → update_gbbq → calc_basic → calc_factor → update_1min → update_5min → update_holidays`
+- Update mode: `update_daily → update_gbbq → calc_basic → calc_factor → update_1min → update_holidays`
 - Init mode: `init_daily` (only import daily data from user-provided directory)
 
 **calc_basic and calc_factor run in full recalculation mode** — they truncate the target table and reimport all rows. This is intentional because preclose/factor depend on the entire history chain.
 
 **Error modes:**
 - `ErrorModeStop` - Stop execution on error (default)
-- `ErrorModeSkip` - Continue execution even if task fails (for optional tasks like update_1min, update_5min, update_holidays)
+- `ErrorModeSkip` - Continue execution even if task fails (for optional tasks like update_1min, update_holidays)
 
 **Task skipping:**
-- Tasks can be skipped by `SkipIf` condition (e.g., minline not set)
+- Tasks can be skipped by `SkipIf` condition (e.g., --min not set)
 - Tasks can also return `StateSkipped` when no new data exists (e.g., non-trading day, data already up to date)
 
 **Usage from cmd/init.go:**
@@ -131,7 +130,7 @@ if !plan.AnyNeeded() {
 }
 executor := workflow.NewTaskExecutor(db, workflow.GetRegisteredTasks())
 args := &workflow.TaskArgs{
-    Minline:   minline,
+    Min:       minEnable,
     TempDir:   TempDir,
     VipdocDir: VipdocDir,
     Today:     GetToday(),

--- a/workflow/engine.go
+++ b/workflow/engine.go
@@ -3,7 +3,6 @@ package workflow
 import (
 	"context"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 
@@ -52,7 +51,7 @@ type Task struct {
 }
 
 type TaskArgs struct {
-	Minline    string
+	Min        bool
 	TempDir    string
 	VipdocDir  string
 	DayFileDir string
@@ -240,30 +239,3 @@ func (te *TaskExecutor) HasTask(name string) bool {
 	return exists
 }
 
-func ParseMinline(minline string) (need1Min, need5Min bool, err error) {
-	if minline == "" {
-		return false, false, nil
-	}
-
-	parts := strings.Split(minline, ",")
-	seen := make(map[string]bool)
-
-	for _, p := range parts {
-		p = strings.TrimSpace(p)
-		if seen[p] {
-			continue
-		}
-		seen[p] = true
-
-		switch p {
-		case "1":
-			need1Min = true
-		case "5":
-			need5Min = true
-		default:
-			return false, false, fmt.Errorf("invalid minline value: %s (expected '1', '5', '1,5')", minline)
-		}
-	}
-
-	return need1Min, need5Min, nil
-}

--- a/workflow/tasks.go
+++ b/workflow/tasks.go
@@ -15,13 +15,12 @@ import (
 )
 
 var (
-	TaskUpdateDaily  *Task
-	TaskInitDaily    *Task
-	TaskUpdateGBBQ   *Task
-	TaskCalcBasic    *Task
-	TaskCalcFactor   *Task
-	TaskUpdate1Min   *Task
-	TaskUpdate5Min   *Task
+	TaskUpdateDaily    *Task
+	TaskInitDaily      *Task
+	TaskUpdateGBBQ     *Task
+	TaskCalcBasic      *Task
+	TaskCalcFactor     *Task
+	TaskUpdate1Min     *Task
 	TaskUpdateHolidays *Task
 )
 
@@ -64,21 +63,9 @@ func init() {
 		Name:      "update_1min",
 		DependsOn: []string{},
 		SkipIf: func(ctx context.Context, db database.DataRepository, args *TaskArgs) bool {
-			need1Min, _, _ := ParseMinline(args.Minline)
-			return !need1Min
+			return !args.Min
 		},
 		Executor: executeUpdate1Min,
-		OnError:  ErrorModeSkip,
-	}
-
-	TaskUpdate5Min = &Task{
-		Name:      "update_5min",
-		DependsOn: []string{},
-		SkipIf: func(ctx context.Context, db database.DataRepository, args *TaskArgs) bool {
-			_, need5Min, _ := ParseMinline(args.Minline)
-			return !need5Min
-		},
-		Executor: executeUpdate5Min,
 		OnError:  ErrorModeSkip,
 	}
 
@@ -235,7 +222,7 @@ func executeCalcFactor(ctx context.Context, db database.DataRepository, args *Ta
 }
 
 func executeUpdate1Min(ctx context.Context, db database.DataRepository, args *TaskArgs) (*TaskResult, error) {
-	latestDate, err := getMinLineLatestDate(db, "1", args)
+	latestDate, err := getMin1LatestDate(db, args)
 	if err != nil {
 		return nil, err
 	}
@@ -270,42 +257,6 @@ func executeUpdate1Min(ctx context.Context, db database.DataRepository, args *Ta
 	return &TaskResult{State: StateSkipped, Message: "no new 1min data"}, nil
 }
 
-func executeUpdate5Min(ctx context.Context, db database.DataRepository, args *TaskArgs) (*TaskResult, error) {
-	latestDate, err := getMinLineLatestDate(db, "5", args)
-	if err != nil {
-		return nil, err
-	}
-
-	validDates, err := prepareTdxData(ctx, latestDate, "tic", args)
-	if err != nil {
-		return nil, fmt.Errorf("failed to prepare tdx data: %w", err)
-	}
-
-	if len(validDates) >= 30 {
-		return nil, fmt.Errorf("分时数据超过30天未更新，请手动补齐后继续")
-	}
-
-	if len(validDates) > 0 {
-		fmt.Printf("🐌 开始转换5分钟分时数据\n")
-
-		stock5MinCSV := filepath.Join(args.TempDir, "5min.csv")
-
-		_, err := tdx.ConvertFilesToCSV(ctx, args.VipdocDir, stock5MinCSV, ".5")
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert .5 files to csv: %w", err)
-		}
-
-		if err := db.ImportKline5Min(stock5MinCSV); err != nil {
-			return nil, fmt.Errorf("failed to import 5-minute line csv: %w", err)
-		}
-		fmt.Println("📊 5分钟数据导入成功")
-		return &TaskResult{State: StateCompleted, Message: "5min data imported"}, nil
-	}
-
-	fmt.Println("🌲 5分钟分时数据无需更新")
-	return &TaskResult{State: StateSkipped, Message: "no new 5min data"}, nil
-}
-
 func executeUpdateHolidays(ctx context.Context, db database.DataRepository, args *TaskArgs) (*TaskResult, error) {
 	fmt.Printf("🐢 导入通达信交易日历\n")
 	zhbZipPath := filepath.Join(args.TempDir, "gbbq-temp", "zhb.zip")
@@ -322,26 +273,19 @@ func executeUpdateHolidays(ctx context.Context, db database.DataRepository, args
 	return &TaskResult{State: StateCompleted, Message: "holidays data imported"}, nil
 }
 
-func getMinLineLatestDate(db database.DataRepository, minline string, args *TaskArgs) (time.Time, error) {
-	var tableName string
-	if minline == "1" {
-		tableName = model.TableKline1Min.TableName
-	} else {
-		tableName = model.TableKline5Min.TableName
-	}
-
-	latestDate, err := db.GetLatestDate(tableName, "datetime")
+func getMin1LatestDate(db database.DataRepository, args *TaskArgs) (time.Time, error) {
+	latestDate, err := db.GetLatestDate(model.TableKline1Min.TableName, "datetime")
 	if err != nil {
 		return time.Time{}, err
 	}
 
 	if latestDate.IsZero() {
-		fmt.Printf("🛑 警告：数据库中没有 %s分钟 数据\n", minline)
+		fmt.Println("🛑 警告：数据库中没有 1分钟 数据")
 		fmt.Println("🚧 将处理今天的数据，历史请自行导入")
 		return args.Today.AddDate(0, 0, -1), nil
 	}
 
-	fmt.Printf("📅 %s分钟数据最新日期为 %s\n", minline, latestDate.Format("2006-01-02"))
+	fmt.Printf("📅 1分钟数据最新日期为 %s\n", latestDate.Format("2006-01-02"))
 	return latestDate, nil
 }
 
@@ -478,7 +422,6 @@ func GetUpdateTaskNames() []string {
 		"calc_basic",
 		"calc_factor",
 		"update_1min",
-		"update_5min",
 		"update_holidays",
 	}
 }
@@ -491,7 +434,6 @@ func GetRegisteredTasks() map[string]*Task {
 		"calc_basic":      TaskCalcBasic,
 		"calc_factor":     TaskCalcFactor,
 		"update_1min":     TaskUpdate1Min,
-		"update_5min":     TaskUpdate5Min,
 		"update_holidays": TaskUpdateHolidays,
 	}
 }


### PR DESCRIPTION
## Summary

- 删 \`raw_kline_5min\` 表 + \`ImportKline5Min\` 接口方法 → schema major bump 3→4
- driver 内部 \`importCSV\` 升级为公开 \`ImportCSV(meta, csvPath)\`
- cron \`--minline 1,5\` 简化为 \`--min\` boolean
- convert \`-t 5min\` 路径整体删除, \`-t tic4\` 不再生成 5min CSV (描述改为"四代分笔转 1 分钟分时")
- tdx 解析仅保留 \`.day\` / \`.01\`, 删 \`.5\` dispatch

## 背景

5min 数据来自 datatool 的 tic→5min 聚合, close 字段在约 12% 的行上与 TDX 软件显示不一致 (OHLV / volume / amount 全对)。源数据无法修正, 因此移除 5min 入库路径, 用户可基于 1min 数据按需聚合。

## Test plan

- [x] \`go build ./...\` + \`go test ./...\` 全过
- [ ] 拿一份现有 v3 DB 跑 cron, 应该被 schema version check 拒绝并提示升级
- [ ] 全新 init 走通, \`raw_kline_5min\` 不再创建, \`raw_kline_1min\` 正常入库
- [ ] \`tdx2db cron --min\` 正常导入 1min 数据
- [ ] \`tdx2db convert -t tic4 -i xxx.zip -o ./\` 只产 1min CSV

Closes #85