### PR TITLE
feat: 增加 -v/version 子命令，对齐本地与 CI 构建版本

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME}"
           DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           go build \
             -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${GITHUB_SHA} -X main.date=${DATE}" \

--- a/main.go
+++ b/main.go
@@ -5,12 +5,47 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"strings"
 	"syscall"
 
 	"github.com/jing2uo/tdx2db/cmd"
 	"github.com/spf13/cobra"
 )
+
+// 由 ldflags 注入（见 .github/workflows/release.yaml）；
+// 未注入时（裸 go build）从 runtime/debug 读 VCS 信息。
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func buildVersionString() string {
+	v, c, d := version, commit, date
+	var dirty bool
+	if v == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			for _, s := range info.Settings {
+				switch s.Key {
+				case "vcs.revision":
+					c = s.Value
+				case "vcs.time":
+					d = s.Value
+				case "vcs.modified":
+					dirty = s.Value == "true"
+				}
+			}
+		}
+	}
+	if len(c) > 7 {
+		c = c[:7]
+	}
+	if dirty {
+		c += " (dirty)"
+	}
+	return fmt.Sprintf("tdx2db %s\ncommit: %s\nbuilt:  %s", v, c, d)
+}
 
 const dbURIInfo = "数据库连接信息"
 const dbURIHelp = `
@@ -44,10 +79,23 @@ func main() {
 		cancel()
 	}()
 
+	versionStr := buildVersionString()
 	var rootCmd = &cobra.Command{
 		Use:           "tdx2db",
 		Short:         "Load TDX Data to DuckDB",
 		SilenceErrors: true,
+		Version:       versionStr,
+	}
+	// 预注册 -v 短选项；cobra 默认只挂 --version
+	rootCmd.Flags().BoolP("version", "v", false, "version for tdx2db")
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+
+	var versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print version information",
+		Run: func(c *cobra.Command, args []string) {
+			fmt.Println(versionStr)
+		},
 	}
 
 	var (
@@ -131,6 +179,7 @@ func main() {
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(cronCmd)
 	rootCmd.AddCommand(convertCmd)
+	rootCmd.AddCommand(versionCmd)
 
 	cobra.OnFinalize(func() {
 		os.RemoveAll(cmd.TempDir)

--- a/makefile
+++ b/makefile
@@ -8,13 +8,19 @@ BIN_NAME      := tdx2db
 INSTALL_DIR   := /usr/local/bin
 LOCAL_BIN     := $(HOME)/.local/bin
 
+# Version info — git tag (例: v4.0-2-g09a5c9d-dirty) / 完整 SHA / UTC 时间
+VERSION       := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT        := $(shell git rev-parse HEAD 2>/dev/null || echo none)
+DATE          := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+LDFLAGS       := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
+
 .PHONY: all build check-unrar download extract move_datatool clean sudo-install user-install
 
 all: build
 
 build: check-unrar download extract move_datatool clean-tmp
-	@echo "Building Go binary..."
-	go build -o $(BIN_NAME)
+	@echo "Building Go binary $(VERSION)..."
+	go build -ldflags="$(LDFLAGS)" -o $(BIN_NAME) .
 
 prepare: check-unrar download extract move_datatool
 	@echo "Prepare datatool..."


### PR DESCRIPTION
## Summary
- 在 `main.go` 声明 `version` / `commit` / `date` 三个 ldflag 变量，root cmd 绑 `Version` 字段并预注册 `-v` 短选项，新增 `version` 子命令
- dev 构建（未注入 ldflags）回落到 `runtime/debug.ReadBuildInfo()` 读 VCS 信息，输出短 SHA + dirty 标记
- `makefile` 改用包级构建（`go build .`）并自动从 `git describe --tags --always --dirty` 注入版本，`make build` 输出形如 `tdx2db v4.0-2-g09a5c9d-dirty`
- `release.yaml` 去掉 `${GITHUB_REF_NAME#v}` 的 `v` 剥离，CI 打 tag 构建输出 `tdx2db v4.0`

## Test plan
- [x] `go build .` → `tdx2db dev / commit: <短哈希> (dirty) / 提交时间`
- [x] `make build` → `tdx2db v4.0-2-g09a5c9d-dirty / 09a5c9d / 构建时间`
- [x] 模拟 CI ldflags 注入 → `tdx2db v4.0 / 09a5c9d / 构建时间`
- [x] `--help` 中显示 `-v, --version` 短选项及 `version` 子命令

🤖 Generated with [Claude Code](https://claude.com/claude-code)