### PR TITLE
chore: 运维杂项 (skip stderr / --temp / GetMinDate / schema v5.0)

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -11,6 +13,41 @@ func GetToday() time.Time {
 	return time.Now().Truncate(24 * time.Hour)
 }
 
+// TempDir / VipdocDir 默认走 $TMPDIR (Linux 通常 /tmp), 通过
+// utils.GetCacheDir 在 package init 时创建唯一子目录。
+// 当 $TMPDIR 容量不够 (如 tmpfs 已被占用大半) 时, 用 --temp 在调用方
+// 切到磁盘大目录, 见 OverrideTempDir。
 var TempDir, _ = utils.GetCacheDir()
 var VipdocDir = filepath.Join(TempDir, "vipdoc")
+
+// OverrideTempDir 把默认 TempDir 切到 parent 下的新 mkdtemp 目录,
+// 同时更新 VipdocDir, 并清掉 package init 创建的原临时目录。
+// 失败时不动现有 TempDir, 调用方可以照常退出。
+func OverrideTempDir(parent string) error {
+	if parent == "" {
+		return nil
+	}
+	// 绝对化: 不然 mkdtemp 出来的是相对路径, 后面 datatool 走
+	// exec.Command(toolPath) + cmd.Dir = cacheDir 时,
+	// 子进程先 chdir 到相对 Dir, 再 execve 相对 Path,
+	// 两段相对路径叠加 → "no such file or directory"。
+	abs, err := filepath.Abs(parent)
+	if err != nil {
+		return fmt.Errorf("abs temp parent %s: %w", parent, err)
+	}
+	if err := os.MkdirAll(abs, 0755); err != nil {
+		return fmt.Errorf("create temp parent %s: %w", abs, err)
+	}
+	dir, err := os.MkdirTemp(abs, "tdx2db-temp-")
+	if err != nil {
+		return fmt.Errorf("mkdir temp under %s: %w", abs, err)
+	}
+	oldTemp := TempDir
+	TempDir = dir
+	VipdocDir = filepath.Join(TempDir, "vipdoc")
+	if oldTemp != "" {
+		_ = os.RemoveAll(oldTemp)
+	}
+	return nil
+}
 

--- a/database/clickhouse/query.go
+++ b/database/clickhouse/query.go
@@ -37,6 +37,19 @@ func (d *ClickHouseDriver) GetLatestDate(tableName string, dateCol string) (time
 	return latest.Time, nil
 }
 
+func (d *ClickHouseDriver) GetMinDate(tableName string, dateCol string) (time.Time, error) {
+	query := fmt.Sprintf("SELECT toDate(minOrNull(%s)) AS earliest FROM %s", dateCol, tableName)
+	var earliest sql.NullTime
+	err := d.db.Get(&earliest, query)
+	if err != nil {
+		return time.Time{}, err
+	}
+	if !earliest.Valid {
+		return time.Time{}, nil
+	}
+	return earliest.Time, nil
+}
+
 func (d *ClickHouseDriver) GetSymbolsByClass(classes ...string) ([]string, error) {
 	if len(classes) == 0 {
 		return nil, nil

--- a/database/duckdb/query.go
+++ b/database/duckdb/query.go
@@ -42,6 +42,22 @@ func (d *DuckDBDriver) GetLatestDate(tableName string, dateCol string) (time.Tim
 	return latest.Time, nil
 }
 
+func (d *DuckDBDriver) GetMinDate(tableName string, dateCol string) (time.Time, error) {
+	query := fmt.Sprintf("SELECT DATE(min(%s)) AS earliest FROM %s", dateCol, tableName)
+
+	var earliest sql.NullTime
+	err := d.db.Get(&earliest, query)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	if !earliest.Valid {
+		return time.Time{}, nil
+	}
+
+	return earliest.Time, nil
+}
+
 func (d *DuckDBDriver) GetSymbolsByClass(classes ...string) ([]string, error) {
 	if len(classes) == 0 {
 		return nil, nil

--- a/database/interface.go
+++ b/database/interface.go
@@ -30,6 +30,7 @@ type DataRepository interface {
 	Query(table string, conditions map[string]interface{}, dest interface{}) error
 	QueryKlineDaily(symbol string, startDate, endDate *time.Time) ([]model.KlineDay, error)
 	GetLatestDate(tableName string, dateCol string) (time.Time, error)
+	GetMinDate(tableName string, dateCol string) (time.Time, error)
 	GetSymbolsByClass(classes ...string) ([]string, error)
 	RebuildSymbolClass() error
 	CountKlineDaily() (int64, error)

--- a/main.go
+++ b/main.go
@@ -80,15 +80,23 @@ func main() {
 	}()
 
 	versionStr := buildVersionString()
+	var tempDirOverride string
 	var rootCmd = &cobra.Command{
 		Use:           "tdx2db",
 		Short:         "Load TDX Data to DuckDB",
 		SilenceErrors: true,
 		Version:       versionStr,
+		PersistentPreRunE: func(c *cobra.Command, args []string) error {
+			return cmd.OverrideTempDir(tempDirOverride)
+		},
 	}
 	// 预注册 -v 短选项；cobra 默认只挂 --version
 	rootCmd.Flags().BoolP("version", "v", false, "version for tdx2db")
 	rootCmd.SetVersionTemplate("{{.Version}}\n")
+	// --temp: 把临时目录的父目录从默认 $TMPDIR 切到指定路径,
+	// 适用 $TMPDIR (常见 /tmp tmpfs) 容量被占满时的兜底。
+	rootCmd.PersistentFlags().StringVar(&tempDirOverride, "temp", "",
+		"临时文件父目录, 留空走 $TMPDIR")
 
 	var versionCmd = &cobra.Command{
 		Use:   "version",

--- a/model/schema.go
+++ b/model/schema.go
@@ -5,7 +5,7 @@ import "time"
 // SchemaMajor 表示数据库 schema 的主版本号。
 // 当发生破坏性变更（表重命名、字段语义变化等）时递增。
 // 已安装的数据库 major 版本与当前代码不匹配时，工具将拒绝操作并提示用户查看文档。
-const SchemaMajor = 4
+const SchemaMajor = 5
 
 // SchemaMinor 表示数据库 schema 的次版本号。
 // 当发生非破坏性变更（新增表、新增字段等）时递增。

--- a/workflow/engine.go
+++ b/workflow/engine.go
@@ -3,6 +3,7 @@ package workflow
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/jing2uo/tdx2db/database"
@@ -166,6 +167,11 @@ func (te *TaskExecutor) Run(ctx context.Context, taskNames []string, args *TaskA
 					}
 					return fmt.Errorf("task %s failed: %w", completed.name, completed.result.Error)
 				}
+				// ErrorModeSkip: 不阻塞流程, 但必须把 error 透出来,
+				// 否则失败的任务在日志里完全无痕, 整体 return nil
+				// 用户看到"今日任务执行成功"很容易误判。
+				fmt.Fprintf(os.Stderr, "💢 任务 %s 失败但已跳过: %v\n",
+					completed.name, completed.result.Error)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- `fix`: `ErrorModeSkip` 任务的 error 透到 stderr, 避免失败任务静默被吞导致"今日全 OK"误判
- `feat`: 全局 `--temp` flag, 把临时目录父目录从 `\$TMPDIR` 切到指定路径 (绕开 tmpfs quota)
- `feat`: `DataRepository.GetMinDate` (GetLatestDate 的对偶, 用于往 DB 前补历史时的起点 cursor)
- `feat!`: schema 主版本升至 v5.0

## Test plan
- [x] `tdx2db cron --temp ~/.cache/tdx2db --dburi 'duckdb://./db' --min` 确认临时目录切到指定路径
- [x] 在 task 上故意制造 error + `OnError=Skip`, 校验 stderr 有 `💢 任务 X 失败但已跳过` 提示
- [x] 新建一个 v5.0 库, 老 v4.x 库启动时应被 schema 校验拒绝并提示迁移