### PR TITLE
fix: 在线板块 / 代码名称任务失败时不阻塞整个 cron

### DIFF
--- a/workflow/task_blocks.go
+++ b/workflow/task_blocks.go
@@ -18,6 +18,7 @@ func init() {
 		Name:      "update_blocks",
 		DependsOn: []string{},
 		Executor:  executeUpdateBlocks,
+		OnError:   ErrorModeSkip,
 	}
 	registerTask(TaskUpdateBlocks, "update")
 }

--- a/workflow/task_symbol.go
+++ b/workflow/task_symbol.go
@@ -18,6 +18,7 @@ func init() {
 		Name:      "update_symbol_names",
 		DependsOn: []string{},
 		Executor:  executeUpdateSymbolNames,
+		OnError:   ErrorModeSkip,
 	}
 	registerTask(TaskUpdateSymbolNames, "update")
 }


### PR DESCRIPTION
## Summary
- `update_blocks` / `update_symbol_names` 走在线 opentdx 协议, 网络/上游异常时默认 `ErrorModeStop` 会 cancel 整个任务图, 把日线 / gbbq 等无关任务也带下水
- 改成 `ErrorModeSkip`, 与 `update_holidays` / `update_1min` 对齐, 错误透出到 stderr 但不阻塞流程

## Test plan
- [x] `go build ./...`
- [ ] 真实 cron 跑一次, 模拟在线接口失败 (e.g. 断网), 确认日线流程仍能跑完

🤖 Generated with [Claude Code](https://claude.com/claude-code)