### PR TITLE
fix: NativeDayMerge makeDayRecord 未设置 reserved 字段导致非 linux/amd64 平台 volume 虚高 100 倍

### DIFF
--- a/tdx/merge.go
+++ b/tdx/merge.go
@@ -198,7 +198,7 @@ func makeDayRecord(date uint32, rec md1OHLCV) []byte {
 	binary.LittleEndian.PutUint32(buf[16:20], uint32(math.Round(rec.Close*100)))
 	binary.LittleEndian.PutUint32(buf[20:24], math.Float32bits(float32(rec.Amount)))
 	binary.LittleEndian.PutUint32(buf[24:28], rec.Volume)
-
+	binary.LittleEndian.PutUint32(buf[28:32], 0x10000)
 	return buf
 }
 


### PR DESCRIPTION
## 问题

在非 linux/amd64 平台（macOS、Windows）上，cron 通过 NativeDayMerge 写入 .day 文件时，
makeDayRecord 使用 make([]byte, recordSize) 创建缓冲区（全零初始化），
导致 reserved 字段（bytes 28-31）为 0x00000000。

parseVolumeOverflow 判断 reserved != 0x10000 时走溢出分支，执行 volRaw × 100，
最终写入数据库的 volume 虚高 100 倍，turnover 同步虚高。

## 现象

- init 阶段（读取 .day 文件）：volume 正常
- cron 阶段（NativeDayMerge 写入新记录）：当天 volume 约为前几天的 100 倍

以 sh600000 为例：

| date       | volume（修复前） | volume（修复后） |
|------------|----------------|----------------|
| 2026-06-03 | 71,007,326     | 71,007,326     |
| 2026-06-04 | 5,609,264,100  | 56,092,641     |

## 原因

TDX .day 文件约定：reserved == 0x10000 表示正常记录，其他值触发溢出解码（× 100）。
makeDayRecord 写入新记录时未显式设置 reserved，导致误判为溢出记录。

## 修复

写入 reserved = 0x10000，与 TDX 原始 .day 文件格式保持一致。