### PR TITLE
test: 修正 TestMakeDayRecord 对 reserved 字段的断言

### DIFF
--- a/tdx/merge_test.go
+++ b/tdx/merge_test.go
@@ -97,10 +97,17 @@ func TestMakeDayRecord(t *testing.T) {
 		t.Errorf("amount = %f, want ~5239992522", amt)
 	}
 
-	// Verify reserved is zero
+	// Verify reserved == 0x10000 (TDX 正常记录标记)，否则读取端
+	// parseVolumeOverflow 会误判为溢出记录并把 volume ×100，导致虚高。
 	reserved := binary.LittleEndian.Uint32(buf[28:32])
-	if reserved != 0 {
-		t.Errorf("reserved = %d, want 0", reserved)
+	if reserved != 0x10000 {
+		t.Errorf("reserved = %#x, want 0x10000", reserved)
+	}
+
+	// 端到端：makeDayRecord 写出的 volume 经 parseVolumeOverflow 读回后
+	// 不应被 ×100。
+	if gotVol := parseVolumeOverflow(volRaw, reserved); gotVol != int64(rec.Volume) {
+		t.Errorf("parseVolumeOverflow round-trip = %d, want %d", gotVol, rec.Volume)
 	}
 }
 


### PR DESCRIPTION
## 背景

PR #105 给 `makeDayRecord` 补了 `reserved = 0x10000`（TDX 正常记录标记），修复了非 linux/amd64 平台 cron 写入新记录后 volume 虚高 100 倍的问题。

但 #105 只改了实现，没同步改测试。`TestMakeDayRecord` 仍断言 `reserved == 0`——而这恰恰是虚高的根因，被固化成了"期望行为"。合并 #105 后该测试会 **FAIL**：

```
merge_test.go:103: reserved = 65536, want 0
```

## 修复

- 断言改为 `reserved == 0x10000`，注释说明原因
- 新增端到端校验：`makeDayRecord` 写出的 volume 经 `parseVolumeOverflow` 读回后不应被 ×100

## 验证

```
ok  github.com/jing2uo/tdx2db/tdx
```
TestMakeDayRecord / TestAppendDayRecordDedup / TestParseVolumeOverflow 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)