### PR TITLE
Fix TDX .day volume parsing

### DIFF
--- a/tdx/kline.go
+++ b/tdx/kline.go
@@ -128,7 +128,7 @@ func processDayFile(data []byte, symbol string) ([]model.KlineDay, error) {
 
 		volRaw := binary.LittleEndian.Uint32(data[offset+24 : offset+28])
 		reserved := binary.LittleEndian.Uint32(data[offset+28 : offset+32])
-		volume := parseVolumeOverflow(volRaw, reserved)
+		volume := parseDayVolume(volRaw, reserved)
 
 		t, err := parseDate(dateRaw)
 		if err != nil {
@@ -203,16 +203,12 @@ func parseDate(d uint32) (time.Time, error) {
 	return time.Date(year, time.Month(month), day, 0, 0, 0, 0, time.Local), nil
 }
 
-// parseVolumeOverflow 处理成交量溢出
-// TDX day 文件中 volume 字段是 uint32，最大约 42.9 亿
-// 当成交量超过此限制时，使用特殊编码:
-//   - reserved (bytes 28-31) 正常值为 0x10000
-//   - 溢出时: volume = volume_raw * 100 + (reserved & 0xFF)
-func parseVolumeOverflow(volRaw, reserved uint32) int64 {
-	if reserved == 0x10000 {
-		return int64(volRaw) // 正常情况
-	}
-	return int64(volRaw)*100 + int64(reserved&0xFF)
+// parseDayVolume returns the .day volume field as shares.
+// The reserved field has varied values in official TDX files and is not a
+// volume overflow marker.
+func parseDayVolume(volRaw, reserved uint32) int64 {
+	_ = reserved
+	return int64(volRaw)
 }
 
 func parseDateTime(dateRaw, timeRaw uint16) (time.Time, error) {

--- a/tdx/kline_test.go
+++ b/tdx/kline_test.go
@@ -1,24 +1,56 @@
 package tdx
 
-import "testing"
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+)
 
-func TestParseVolumeOverflow(t *testing.T) {
+func TestParseDayVolumeIgnoresReserved(t *testing.T) {
 	tests := []struct {
 		name     string
 		volRaw   uint32
 		reserved uint32
 		want     int64
 	}{
-		{"normal", 189_000_000, 0x10000, 189_000_000},
-		{"overflow sh601868 2025-03-12", 478_000_000, 0x00000000, 47_800_000_000},
-		{"overflow with low byte", 478_000_000, 0x0000002A, 47_800_000_042},
+		{"modern reserved", 189_000_000, 0x10000, 189_000_000},
+		{"early sz reserved zero", 25_859_600, 0x00000000, 25_859_600},
+		{"early sh reserved 1000", 174_085_000, 0x000003E8, 174_085_000},
+		{"early sh reserved 3139", 40_631_800, 0x00000C43, 40_631_800},
+		{"nonzero low byte", 478_000_000, 0x0000002A, 478_000_000},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := parseVolumeOverflow(tt.volRaw, tt.reserved)
+			got := parseDayVolume(tt.volRaw, tt.reserved)
 			if got != tt.want {
-				t.Errorf("parseVolumeOverflow(%d, 0x%x) = %d, want %d", tt.volRaw, tt.reserved, got, tt.want)
+				t.Errorf("parseDayVolume(%d, 0x%x) = %d, want %d", tt.volRaw, tt.reserved, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestProcessDayFileIgnoresReservedForVolume(t *testing.T) {
+	data := make([]byte, recordSize)
+	binary.LittleEndian.PutUint32(data[0:4], 19991110)
+	binary.LittleEndian.PutUint32(data[4:8], 2775)
+	binary.LittleEndian.PutUint32(data[8:12], 2775)
+	binary.LittleEndian.PutUint32(data[12:16], 2775)
+	binary.LittleEndian.PutUint32(data[16:20], 2775)
+	binary.LittleEndian.PutUint32(data[20:24], math.Float32bits(float32(4_859_102_208)))
+	binary.LittleEndian.PutUint32(data[24:28], 174_085_000)
+	binary.LittleEndian.PutUint32(data[28:32], 0x000003E8)
+
+	rows, err := processDayFile(data, "sh600000")
+	if err != nil {
+		t.Fatalf("processDayFile: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if rows[0].Volume != 174_085_000 {
+		t.Errorf("volume = %d, want 174085000", rows[0].Volume)
+	}
+	if rows[0].Close != 27.75 {
+		t.Errorf("close = %f, want 27.75", rows[0].Close)
 	}
 }

--- a/tdx/merge_test.go
+++ b/tdx/merge_test.go
@@ -20,8 +20,8 @@ func TestParseIncrFilename(t *testing.T) {
 		{"bj260318.md1", "bj", 20260318, false},
 		{"sh990101.md1", "sh", 19990101, false},
 		{"sh250610.md1", "sh", 20250610, false},
-		{"ab.md1", "", 0, true},       // too short
-		{"sh13.md1", "", 0, true},     // too short date part
+		{"ab.md1", "", 0, true},   // too short
+		{"sh13.md1", "", 0, true}, // too short date part
 	}
 
 	for _, tt := range tests {
@@ -97,17 +97,16 @@ func TestMakeDayRecord(t *testing.T) {
 		t.Errorf("amount = %f, want ~5239992522", amt)
 	}
 
-	// Verify reserved == 0x10000 (TDX 正常记录标记)，否则读取端
-	// parseVolumeOverflow 会误判为溢出记录并把 volume ×100，导致虚高。
+	// Verify generated records keep the conventional reserved value.
+	// The reader ignores this field when parsing volume.
 	reserved := binary.LittleEndian.Uint32(buf[28:32])
 	if reserved != 0x10000 {
 		t.Errorf("reserved = %#x, want 0x10000", reserved)
 	}
 
-	// 端到端：makeDayRecord 写出的 volume 经 parseVolumeOverflow 读回后
-	// 不应被 ×100。
-	if gotVol := parseVolumeOverflow(volRaw, reserved); gotVol != int64(rec.Volume) {
-		t.Errorf("parseVolumeOverflow round-trip = %d, want %d", gotVol, rec.Volume)
+	// End-to-end: makeDayRecord volume should round-trip unchanged.
+	if gotVol := parseDayVolume(volRaw, reserved); gotVol != int64(rec.Volume) {
+		t.Errorf("parseDayVolume round-trip = %d, want %d", gotVol, rec.Volume)
 	}
 }
 


### PR DESCRIPTION
Summary:
- Treat the .day volume field as the final share volume.
- Stop interpreting reserved != 0x10000 as a volume overflow marker.
- Add unit and parser-path coverage for historical reserved values.

Verification:
- env GOCACHE=/tmp/tdx2db-gocache go test ./...

Closes #113
Closes #109