### PR TITLE
修复etf价格缩小问题

### DIFF
--- a/merge.go
+++ b/merge.go
@@ -1,0 +1,288 @@
+package tdx
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jing2uo/tdx2db/model"
+)
+
+const (
+	codRecordSize = 150
+	md1BlockSize  = 512
+)
+
+// codEntry represents a single record parsed from a TDX .cod file.
+// The .cod file maps stock codes to sequence numbers used to locate
+// corresponding data blocks in the paired .md1 file.
+type codEntry struct {
+	StockCode string // [0:6] ASCII stock code (e.g. "600519")
+	SeqNum    uint16 // [32:34] sequence number → md1 offset = SeqNum * 512
+}
+
+// md1OHLCV holds OHLCV data extracted from one 512-byte block in a .md1 file.
+type md1OHLCV struct {
+	Open   float64 // [12:20] double
+	High   float64 // [20:28] double
+	Low    float64 // [28:36] double
+	Close  float64 // [36:44] double
+	Amount float64 // [72:80] double (turnover in yuan)
+	Volume uint32  // [56:60] uint32 (in shares)
+}
+
+// NativeDayMerge reads all .md1/.cod file pairs from vipdocDir/refmhq/ and
+// merges the parsed records into per-stock .day files under vipdocDir/{exchange}/lday/.
+//
+// TDX distributes daily incremental data as .md1 (market data, 512 bytes/block)
+// and .cod (code mapping, 150 bytes/record) file pairs. Each .cod record maps
+// a stock code to a sequence number that locates its data block in the .md1 file
+// at offset = seqNum * 512.
+//
+// This function replaces the external datatool binary for the "day" subcommand,
+// enabling native cross-platform support (including macOS arm64).
+func NativeDayMerge(vipdocDir string) error {
+	refmhqDir := filepath.Join(vipdocDir, "refmhq")
+
+	md1Files, err := filepath.Glob(filepath.Join(refmhqDir, "*.md1"))
+	if err != nil {
+		return fmt.Errorf("failed to glob md1 files: %w", err)
+	}
+
+	if len(md1Files) == 0 {
+		return nil
+	}
+
+	sort.Strings(md1Files)
+
+	for _, md1File := range md1Files {
+		baseName := filepath.Base(md1File)
+		codFile := filepath.Join(refmhqDir, strings.TrimSuffix(baseName, ".md1")+".cod")
+
+		if _, err := os.Stat(codFile); os.IsNotExist(err) {
+			continue
+		}
+
+		exchange, dateVal, err := parseIncrFilename(baseName)
+		if err != nil {
+			continue
+		}
+
+		if err := mergeSingleDay(vipdocDir, exchange, dateVal, codFile, md1File); err != nil {
+			return fmt.Errorf("merge %s failed: %w", baseName, err)
+		}
+	}
+
+	return nil
+}
+
+// parseIncrFilename extracts exchange prefix and date from filenames like "sh260318.md1".
+// Returns exchange ("sh"|"sz"|"bj") and date as YYYYMMDD uint32 (e.g. 20260318).
+func parseIncrFilename(name string) (exchange string, dateVal uint32, err error) {
+	base := strings.SplitN(name, ".", 2)[0]
+	if len(base) < 8 {
+		return "", 0, fmt.Errorf("filename too short: %s", name)
+	}
+
+	exchange = base[:2]
+	dateStr := base[2:]
+	if len(dateStr) != 6 {
+		return "", 0, fmt.Errorf("invalid date part in filename: %s", dateStr)
+	}
+
+	yy := int(dateStr[0]-'0')*10 + int(dateStr[1]-'0')
+	mm := int(dateStr[2]-'0')*10 + int(dateStr[3]-'0')
+	dd := int(dateStr[4]-'0')*10 + int(dateStr[5]-'0')
+
+	year := 2000 + yy
+	if year > 2080 {
+		year -= 100
+	}
+
+	if mm < 1 || mm > 12 || dd < 1 || dd > 31 {
+		return "", 0, fmt.Errorf("invalid date: %d-%02d-%02d", year, mm, dd)
+	}
+
+	dateVal = uint32(year*10000 + mm*100 + dd)
+	return exchange, dateVal, nil
+}
+
+// parseCodEntries reads a .cod file and returns all stock code → sequence number mappings.
+//
+// .cod file format (150 bytes per record):
+//
+//	[0:6]   char[6]  stock code (ASCII, e.g. "600519")
+//	[32:34] uint16   sequence number (LE) → md1 block offset = seq * 512
+func parseCodEntries(codFile string) ([]codEntry, error) {
+	data, err := os.ReadFile(codFile)
+	if err != nil {
+		return nil, fmt.Errorf("read cod file: %w", err)
+	}
+
+	if len(data)%codRecordSize != 0 {
+		return nil, fmt.Errorf("invalid cod file size %d (not divisible by %d)", len(data), codRecordSize)
+	}
+
+	count := len(data) / codRecordSize
+	entries := make([]codEntry, 0, count)
+
+	for i := 0; i < count; i++ {
+		offset := i * codRecordSize
+		rec := data[offset : offset+codRecordSize]
+
+		code := strings.TrimRight(string(rec[0:6]), "\x00 ")
+		if code == "" {
+			continue
+		}
+
+		seqNum := binary.LittleEndian.Uint16(rec[32:34])
+
+		entries = append(entries, codEntry{
+			StockCode: code,
+			SeqNum:    seqNum,
+		})
+	}
+
+	return entries, nil
+}
+
+// readMd1Block extracts OHLCV data from the 512-byte block at the given sequence index.
+//
+// .md1 file format (512 bytes per block):
+//
+//	[12:20] float64  open price
+//	[20:28] float64  high price
+//	[28:36] float64  low price
+//	[36:44] float64  close price
+//	[56:60] uint32   volume (in shares)
+//	[72:80] float64  amount (turnover in yuan)
+func readMd1Block(md1Data []byte, seqNum uint16) (md1OHLCV, error) {
+	offset := int(seqNum) * md1BlockSize
+	if offset+md1BlockSize > len(md1Data) {
+		return md1OHLCV{}, fmt.Errorf("md1 offset %d out of range (size %d)", offset, len(md1Data))
+	}
+
+	blk := md1Data[offset : offset+md1BlockSize]
+
+	return md1OHLCV{
+		Open:   math.Float64frombits(binary.LittleEndian.Uint64(blk[12:20])),
+		High:   math.Float64frombits(binary.LittleEndian.Uint64(blk[20:28])),
+		Low:    math.Float64frombits(binary.LittleEndian.Uint64(blk[28:36])),
+		Close:  math.Float64frombits(binary.LittleEndian.Uint64(blk[36:44])),
+		Volume: binary.LittleEndian.Uint32(blk[56:60]),
+		Amount: math.Float64frombits(binary.LittleEndian.Uint64(blk[72:80])),
+	}, nil
+}
+
+// makeDayRecord encodes one 32-byte .day record from OHLCV data and a date.
+//
+// .day file format (32 bytes per record, little-endian):
+//
+//	[0:4]   uint32   date (YYYYMMDD)
+//	[4:8]   uint32   open (price * scale)
+//	[8:12]  uint32   high (price * scale)
+//	[12:16] uint32   low (price * scale)
+//	[16:20] uint32   close (price * scale)
+//	[20:24] float32  amount (IEEE 754)
+//	[24:28] uint32   volume
+//	[28:32] uint32   reserved
+//
+// scale 由 model.PriceScale(symbol) 决定: 股票=100, ETF/LOF/B股=1000
+func makeDayRecord(date uint32, rec md1OHLCV, scale float64) []byte {
+	buf := make([]byte, recordSize)
+
+	binary.LittleEndian.PutUint32(buf[0:4], date)
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(math.Round(rec.Open*scale)))
+	binary.LittleEndian.PutUint32(buf[8:12], uint32(math.Round(rec.High*scale)))
+	binary.LittleEndian.PutUint32(buf[12:16], uint32(math.Round(rec.Low*scale)))
+	binary.LittleEndian.PutUint32(buf[16:20], uint32(math.Round(rec.Close*scale)))
+	binary.LittleEndian.PutUint32(buf[20:24], math.Float32bits(float32(rec.Amount)))
+	binary.LittleEndian.PutUint32(buf[24:28], rec.Volume)
+	binary.LittleEndian.PutUint32(buf[28:32], 0x10000)
+	return buf
+}
+
+// mergeSingleDay processes one .cod+.md1 pair for a single exchange and date,
+// appending new records to the corresponding per-stock .day files.
+func mergeSingleDay(vipdocDir, exchange string, date uint32, codFile, md1File string) error {
+	entries, err := parseCodEntries(codFile)
+	if err != nil {
+		return err
+	}
+
+	md1Data, err := os.ReadFile(md1File)
+	if err != nil {
+		return fmt.Errorf("read md1: %w", err)
+	}
+
+	ldayDir := filepath.Join(vipdocDir, exchange, "lday")
+	if err := os.MkdirAll(ldayDir, 0755); err != nil {
+		return fmt.Errorf("create lday dir: %w", err)
+	}
+
+	for _, ent := range entries {
+		ohlcv, err := readMd1Block(md1Data, ent.SeqNum)
+		if err != nil {
+			continue
+		}
+
+		if ohlcv.Volume == 0 && ohlcv.Amount == 0 {
+			continue
+		}
+
+		if ohlcv.Open <= 0 || ohlcv.Close <= 0 {
+			continue
+		}
+
+		dayFileName := fmt.Sprintf("%s%s.day", exchange, ent.StockCode)
+		dayFilePath := filepath.Join(ldayDir, dayFileName)
+
+		symbol := exchange + ent.StockCode
+		scale := model.PriceScale(symbol)
+		dayRec := makeDayRecord(date, ohlcv, scale)
+
+		if err := appendDayRecord(dayFilePath, date, dayRec); err != nil {
+			continue
+		}
+	}
+
+	return nil
+}
+
+// appendDayRecord appends a 32-byte record to a .day file.
+// It deduplicates by checking whether the file's last record already
+// has the same or a newer date.
+func appendDayRecord(path string, date uint32, record []byte) error {
+	fi, err := os.Stat(path)
+	if err == nil && fi.Size() >= recordSize {
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		lastRec := make([]byte, recordSize)
+		_, readErr := f.ReadAt(lastRec, fi.Size()-recordSize)
+		f.Close()
+		if readErr != nil {
+			return readErr
+		}
+
+		lastDate := binary.LittleEndian.Uint32(lastRec[0:4])
+		if lastDate >= date {
+			return nil
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.Write(record)
+	return err
+}

--- a/merge_test.go
+++ b/merge_test.go
@@ -1,0 +1,240 @@
+package tdx
+
+import (
+	"encoding/binary"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseIncrFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		wantExch string
+		wantDate uint32
+		wantErr  bool
+	}{
+		{"sh260318.md1", "sh", 20260318, false},
+		{"sz260318.cod", "sz", 20260318, false},
+		{"bj260318.md1", "bj", 20260318, false},
+		{"sh990101.md1", "sh", 19990101, false},
+		{"sh250610.md1", "sh", 20250610, false},
+		{"ab.md1", "", 0, true},   // too short
+		{"sh13.md1", "", 0, true}, // too short date part
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exch, date, err := parseIncrFilename(tt.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseIncrFilename(%q) error = %v, wantErr %v", tt.name, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if exch != tt.wantExch || date != tt.wantDate {
+					t.Errorf("parseIncrFilename(%q) = (%q, %d), want (%q, %d)",
+						tt.name, exch, date, tt.wantExch, tt.wantDate)
+				}
+			}
+		})
+	}
+}
+
+func TestMakeDayRecord(t *testing.T) {
+	rec := md1OHLCV{
+		Open:   1489.00,
+		High:   1496.50,
+		Low:    1463.15,
+		Close:  1468.80,
+		Amount: 5239992522.0,
+		Volume: 3555100,
+	}
+
+	buf := makeDayRecord(20260318, rec, 100)
+
+	if len(buf) != recordSize {
+		t.Fatalf("expected %d bytes, got %d", recordSize, len(buf))
+	}
+
+	// Verify date
+	date := binary.LittleEndian.Uint32(buf[0:4])
+	if date != 20260318 {
+		t.Errorf("date = %d, want 20260318", date)
+	}
+
+	// Verify OHLC (price * 100)
+	openRaw := binary.LittleEndian.Uint32(buf[4:8])
+	if openRaw != 148900 {
+		t.Errorf("open = %d, want 148900", openRaw)
+	}
+
+	highRaw := binary.LittleEndian.Uint32(buf[8:12])
+	if highRaw != 149650 {
+		t.Errorf("high = %d, want 149650", highRaw)
+	}
+
+	lowRaw := binary.LittleEndian.Uint32(buf[12:16])
+	if lowRaw != 146315 {
+		t.Errorf("low = %d, want 146315", lowRaw)
+	}
+
+	closeRaw := binary.LittleEndian.Uint32(buf[16:20])
+	if closeRaw != 146880 {
+		t.Errorf("close = %d, want 146880", closeRaw)
+	}
+
+	// Verify volume
+	volRaw := binary.LittleEndian.Uint32(buf[24:28])
+	if volRaw != 3555100 {
+		t.Errorf("volume = %d, want 3555100", volRaw)
+	}
+
+	// Verify amount (float32)
+	amtBits := binary.LittleEndian.Uint32(buf[20:24])
+	amt := math.Float32frombits(amtBits)
+	if math.Abs(float64(amt)-5239992522.0) > 1e6 { // float32 precision
+		t.Errorf("amount = %f, want ~5239992522", amt)
+	}
+
+	// Verify generated records keep the conventional reserved value.
+	// The reader ignores this field when parsing volume.
+	reserved := binary.LittleEndian.Uint32(buf[28:32])
+	if reserved != 0x10000 {
+		t.Errorf("reserved = %#x, want 0x10000", reserved)
+	}
+
+	// End-to-end: makeDayRecord volume should round-trip unchanged.
+	if gotVol := parseDayVolume(volRaw, reserved); gotVol != int64(rec.Volume) {
+		t.Errorf("parseDayVolume round-trip = %d, want %d", gotVol, rec.Volume)
+	}
+}
+
+func TestAppendDayRecordDedup(t *testing.T) {
+	tmpDir := t.TempDir()
+	dayFile := filepath.Join(tmpDir, "test.day")
+
+	rec := md1OHLCV{Open: 10, High: 11, Low: 9, Close: 10.5, Amount: 1000, Volume: 100}
+	buf := makeDayRecord(20260318, rec, 100)
+
+	// First write
+	if err := appendDayRecord(dayFile, 20260318, buf); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+
+	fi1, _ := os.Stat(dayFile)
+	if fi1.Size() != int64(recordSize) {
+		t.Fatalf("expected %d bytes after first write, got %d", recordSize, fi1.Size())
+	}
+
+	// Duplicate write — should be skipped
+	if err := appendDayRecord(dayFile, 20260318, buf); err != nil {
+		t.Fatalf("duplicate append: %v", err)
+	}
+
+	fi2, _ := os.Stat(dayFile)
+	if fi2.Size() != int64(recordSize) {
+		t.Errorf("dedup failed: size grew from %d to %d", fi1.Size(), fi2.Size())
+	}
+
+	// Older date — should also be skipped
+	oldBuf := makeDayRecord(20260317, rec, 100)
+	if err := appendDayRecord(dayFile, 20260317, oldBuf); err != nil {
+		t.Fatalf("old date append: %v", err)
+	}
+
+	fi3, _ := os.Stat(dayFile)
+	if fi3.Size() != int64(recordSize) {
+		t.Errorf("old date was not skipped: size = %d", fi3.Size())
+	}
+
+	// Newer date — should be appended
+	newBuf := makeDayRecord(20260319, rec, 100)
+	if err := appendDayRecord(dayFile, 20260319, newBuf); err != nil {
+		t.Fatalf("new date append: %v", err)
+	}
+
+	fi4, _ := os.Stat(dayFile)
+	if fi4.Size() != int64(2*recordSize) {
+		t.Errorf("new date not appended: size = %d, want %d", fi4.Size(), 2*recordSize)
+	}
+}
+
+func TestParseCodEntries(t *testing.T) {
+	// Create a minimal synthetic .cod file with 2 records
+	tmpDir := t.TempDir()
+	codFile := filepath.Join(tmpDir, "test.cod")
+
+	data := make([]byte, 2*codRecordSize)
+
+	// Record 0: code "600519", seq=42
+	copy(data[0:6], "600519")
+	binary.LittleEndian.PutUint16(data[32:34], 42)
+
+	// Record 1: code "000001", seq=7
+	copy(data[codRecordSize:codRecordSize+6], "000001")
+	binary.LittleEndian.PutUint16(data[codRecordSize+32:codRecordSize+34], 7)
+
+	if err := os.WriteFile(codFile, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := parseCodEntries(codFile)
+	if err != nil {
+		t.Fatalf("parseCodEntries: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+
+	if entries[0].StockCode != "600519" || entries[0].SeqNum != 42 {
+		t.Errorf("entry 0: got (%q, %d), want (600519, 42)", entries[0].StockCode, entries[0].SeqNum)
+	}
+
+	if entries[1].StockCode != "000001" || entries[1].SeqNum != 7 {
+		t.Errorf("entry 1: got (%q, %d), want (000001, 7)", entries[1].StockCode, entries[1].SeqNum)
+	}
+}
+
+func TestReadMd1Block(t *testing.T) {
+	// Create a synthetic md1 block at seq=0
+	data := make([]byte, md1BlockSize)
+
+	// Write known OHLCV values
+	binary.LittleEndian.PutUint64(data[12:20], math.Float64bits(100.50))  // open
+	binary.LittleEndian.PutUint64(data[20:28], math.Float64bits(105.00))  // high
+	binary.LittleEndian.PutUint64(data[28:36], math.Float64bits(99.00))   // low
+	binary.LittleEndian.PutUint64(data[36:44], math.Float64bits(103.25))  // close
+	binary.LittleEndian.PutUint32(data[56:60], 50000)                     // volume
+	binary.LittleEndian.PutUint64(data[72:80], math.Float64bits(5000000)) // amount
+
+	ohlcv, err := readMd1Block(data, 0)
+	if err != nil {
+		t.Fatalf("readMd1Block: %v", err)
+	}
+
+	if ohlcv.Open != 100.50 {
+		t.Errorf("open = %f, want 100.50", ohlcv.Open)
+	}
+	if ohlcv.High != 105.00 {
+		t.Errorf("high = %f, want 105.00", ohlcv.High)
+	}
+	if ohlcv.Low != 99.00 {
+		t.Errorf("low = %f, want 99.00", ohlcv.Low)
+	}
+	if ohlcv.Close != 103.25 {
+		t.Errorf("close = %f, want 103.25", ohlcv.Close)
+	}
+	if ohlcv.Volume != 50000 {
+		t.Errorf("volume = %d, want 50000", ohlcv.Volume)
+	}
+	if ohlcv.Amount != 5000000 {
+		t.Errorf("amount = %f, want 5000000", ohlcv.Amount)
+	}
+
+	// Out of range
+	if _, err := readMd1Block(data, 1); err == nil {
+		t.Error("expected error for out-of-range seq")
+	}
+}


### PR DESCRIPTION
## 修复内容
1. tdx/merge.go makeDayRecord 接收 scale 参数，替代硬编码的100
2. tdx/merge.go mergeSingleDay 中根据 model.PriceScale(symbol) 计算正确的scale传入
3. tdx/merge_test.go 更新测试调用以匹配新签名