### PR TITLE
fix: 按品种缩放日线价格, 修复 ETF 价格缩小问题

### DIFF
--- a/tdx/merge.go
+++ b/tdx/merge.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/jing2uo/tdx2db/model"
 )
 
 const (
@@ -181,21 +183,23 @@ func readMd1Block(md1Data []byte, seqNum uint16) (md1OHLCV, error) {
 // .day file format (32 bytes per record, little-endian):
 //
 //	[0:4]   uint32   date (YYYYMMDD)
-//	[4:8]   uint32   open (price * 100)
-//	[8:12]  uint32   high (price * 100)
-//	[12:16] uint32   low (price * 100)
-//	[16:20] uint32   close (price * 100)
+//	[4:8]   uint32   open (price * scale)
+//	[8:12]  uint32   high (price * scale)
+//	[12:16] uint32   low (price * scale)
+//	[16:20] uint32   close (price * scale)
 //	[20:24] float32  amount (IEEE 754)
 //	[24:28] uint32   volume
 //	[28:32] uint32   reserved
-func makeDayRecord(date uint32, rec md1OHLCV) []byte {
+//
+// scale 由 model.PriceScale(symbol) 决定: 股票=100, ETF/LOF/B股=1000
+func makeDayRecord(date uint32, rec md1OHLCV, scale float64) []byte {
 	buf := make([]byte, recordSize)
 
 	binary.LittleEndian.PutUint32(buf[0:4], date)
-	binary.LittleEndian.PutUint32(buf[4:8], uint32(math.Round(rec.Open*100)))
-	binary.LittleEndian.PutUint32(buf[8:12], uint32(math.Round(rec.High*100)))
-	binary.LittleEndian.PutUint32(buf[12:16], uint32(math.Round(rec.Low*100)))
-	binary.LittleEndian.PutUint32(buf[16:20], uint32(math.Round(rec.Close*100)))
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(math.Round(rec.Open*scale)))
+	binary.LittleEndian.PutUint32(buf[8:12], uint32(math.Round(rec.High*scale)))
+	binary.LittleEndian.PutUint32(buf[12:16], uint32(math.Round(rec.Low*scale)))
+	binary.LittleEndian.PutUint32(buf[16:20], uint32(math.Round(rec.Close*scale)))
 	binary.LittleEndian.PutUint32(buf[20:24], math.Float32bits(float32(rec.Amount)))
 	binary.LittleEndian.PutUint32(buf[24:28], rec.Volume)
 	binary.LittleEndian.PutUint32(buf[28:32], 0x10000)
@@ -237,7 +241,9 @@ func mergeSingleDay(vipdocDir, exchange string, date uint32, codFile, md1File st
 		dayFileName := fmt.Sprintf("%s%s.day", exchange, ent.StockCode)
 		dayFilePath := filepath.Join(ldayDir, dayFileName)
 
-		dayRec := makeDayRecord(date, ohlcv)
+		symbol := exchange + ent.StockCode
+		scale := model.PriceScale(symbol)
+		dayRec := makeDayRecord(date, ohlcv, scale)
 
 		if err := appendDayRecord(dayFilePath, date, dayRec); err != nil {
 			continue

--- a/tdx/merge_test.go
+++ b/tdx/merge_test.go
@@ -51,7 +51,7 @@ func TestMakeDayRecord(t *testing.T) {
 		Volume: 3555100,
 	}
 
-	buf := makeDayRecord(20260318, rec)
+	buf := makeDayRecord(20260318, rec, 100)
 
 	if len(buf) != recordSize {
 		t.Fatalf("expected %d bytes, got %d", recordSize, len(buf))
@@ -115,7 +115,7 @@ func TestAppendDayRecordDedup(t *testing.T) {
 	dayFile := filepath.Join(tmpDir, "test.day")
 
 	rec := md1OHLCV{Open: 10, High: 11, Low: 9, Close: 10.5, Amount: 1000, Volume: 100}
-	buf := makeDayRecord(20260318, rec)
+	buf := makeDayRecord(20260318, rec, 100)
 
 	// First write
 	if err := appendDayRecord(dayFile, 20260318, buf); err != nil {
@@ -138,7 +138,7 @@ func TestAppendDayRecordDedup(t *testing.T) {
 	}
 
 	// Older date — should also be skipped
-	oldBuf := makeDayRecord(20260317, rec)
+	oldBuf := makeDayRecord(20260317, rec, 100)
 	if err := appendDayRecord(dayFile, 20260317, oldBuf); err != nil {
 		t.Fatalf("old date append: %v", err)
 	}
@@ -149,7 +149,7 @@ func TestAppendDayRecordDedup(t *testing.T) {
 	}
 
 	// Newer date — should be appended
-	newBuf := makeDayRecord(20260319, rec)
+	newBuf := makeDayRecord(20260319, rec, 100)
 	if err := appendDayRecord(dayFile, 20260319, newBuf); err != nil {
 		t.Fatalf("new date append: %v", err)
 	}


### PR DESCRIPTION
重做 #117。原 PR 修的是对的,但把 `merge.go`/`merge_test.go` 作为完整副本放到了**仓库根目录**(`package tdx`),没有落到真实的 `tdx/` 包里,会导致重复定义/编译冲突。本 PR 把等价改动直接应用到 `tdx/merge.go` 和 `tdx/merge_test.go`。

## 改动
1. `makeDayRecord` 接收 `scale float64` 参数,替代硬编码的 `100`
2. `mergeSingleDay` 用 `model.PriceScale(symbol)` 计算正确 scale(股票=100,ETF/LOF/B股=1000)后传入
3. `merge_test.go` 更新调用以匹配新签名

`go build ./...` 与 `go test ./tdx/` 均通过。

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)