### PR TITLE
fix: 修复 md1 ETF 成交量溢出并导入指数涨跌家数

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ tdx2db cron --dburi 'duckdb://tdx.db' --min
 
 | 表 / 视图               | 说明                              |
 | :---------------------- | :-------------------------------- |
-| `_meta`                 | schema 版本等元信息 (当前 v5.0)   |
-| `raw_kline_daily`       | 日线 (股票 / 指数 / ETF / 板块)   |
+| `_meta`                 | schema 版本等元信息 (当前 v6.0)   |
+| `raw_kline_daily`       | 日线；指数/板块含涨跌家数         |
 | `raw_kline_1min`        | 1 分钟 K 线                       |
 | `raw_basic_daily`       | 股票 / ETF 前收盘价、换手率与市值 |
 | `raw_adjust_factor`     | 后复权因子                        |

--- a/model/schema.go
+++ b/model/schema.go
@@ -5,21 +5,23 @@ import "time"
 // SchemaMajor 表示数据库 schema 的主版本号。
 // 当发生破坏性变更（表重命名、字段语义变化等）时递增。
 // 已安装的数据库 major 版本与当前代码不匹配时，工具将拒绝操作并提示用户查看文档。
-const SchemaMajor = 5
+const SchemaMajor = 6
 
 // SchemaMinor 表示数据库 schema 的次版本号。
 // 当发生非破坏性变更（新增表、新增字段等）时递增。
 const SchemaMinor = 0
 
 type KlineDay struct {
-	Symbol string    `col:"symbol"`
-	Open   float64   `col:"open"`
-	High   float64   `col:"high"`
-	Low    float64   `col:"low"`
-	Close  float64   `col:"close"`
-	Amount float64   `col:"amount"`
-	Volume int64     `col:"volume"`
-	Date   time.Time `col:"date" type:"date"`
+	Symbol    string    `col:"symbol"`
+	Open      float64   `col:"open"`
+	High      float64   `col:"high"`
+	Low       float64   `col:"low"`
+	Close     float64   `col:"close"`
+	Amount    float64   `col:"amount"`
+	Volume    int64     `col:"volume"`
+	UpCount   int64     `col:"up_count"`
+	DownCount int64     `col:"down_count"`
+	Date      time.Time `col:"date" type:"date"`
 }
 
 type KlineMin struct {

--- a/model/tables_test.go
+++ b/model/tables_test.go
@@ -18,3 +18,17 @@ func TestSchemaFromStructNullableTag(t *testing.T) {
 		t.Fatalf("expected nullable column")
 	}
 }
+
+func TestKlineDailyIncludesBreadthColumns(t *testing.T) {
+	want := map[string]bool{"up_count": false, "down_count": false}
+	for _, col := range TableKlineDaily.Columns {
+		if _, ok := want[col.Name]; ok {
+			want[col.Name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("raw_kline_daily missing %s column", name)
+		}
+	}
+}

--- a/tdx/kline.go
+++ b/tdx/kline.go
@@ -111,6 +111,7 @@ func processDayFile(data []byte, symbol string) ([]model.KlineDay, error) {
 	count := n / recordSize
 	rows := make([]model.KlineDay, 0, count)
 	scale := model.PriceScale(symbol)
+	indexMode := isIndexMode(symbol)
 
 	var offset int
 	for i := 0; i < count; i++ {
@@ -127,7 +128,13 @@ func processDayFile(data []byte, symbol string) ([]model.KlineDay, error) {
 
 		volRaw := binary.LittleEndian.Uint32(data[offset+24 : offset+28])
 		reserved := binary.LittleEndian.Uint32(data[offset+28 : offset+32])
-		volume := parseDayVolume(volRaw, reserved)
+		volume := int64(volRaw)
+		var upCount, downCount int64
+		if indexMode {
+			upCount, downCount = parseDayBreadth(reserved)
+		} else {
+			volume = parseDayVolume(volRaw, reserved)
+		}
 
 		t, err := parseDate(dateRaw)
 		if err != nil {
@@ -135,14 +142,16 @@ func processDayFile(data []byte, symbol string) ([]model.KlineDay, error) {
 		}
 
 		rows = append(rows, model.KlineDay{
-			Symbol: symbol,
-			Open:   float64(openRaw) / scale,
-			High:   float64(highRaw) / scale,
-			Low:    float64(lowRaw) / scale,
-			Close:  float64(closeRaw) / scale,
-			Amount: float64(amount),
-			Volume: volume,
-			Date:   t,
+			Symbol:    symbol,
+			Open:      float64(openRaw) / scale,
+			High:      float64(highRaw) / scale,
+			Low:       float64(lowRaw) / scale,
+			Close:     float64(closeRaw) / scale,
+			Amount:    float64(amount),
+			Volume:    volume,
+			UpCount:   upCount,
+			DownCount: downCount,
+			Date:      t,
 		})
 	}
 	return rows, nil
@@ -207,6 +216,15 @@ func parseDayVolume(volRaw, reserved uint32) int64 {
 		return int64(volRaw)*100 + int64(reserved&0xff)
 	}
 	return int64(volRaw)
+}
+
+func parseDayBreadth(reserved uint32) (upCount, downCount int64) {
+	return int64(reserved & 0xffff), int64(reserved >> 16)
+}
+
+func isIndexMode(symbol string) bool {
+	class := model.ClassifyCode(symbol)
+	return class == model.ClassIndex || class == model.ClassBlock
 }
 
 func parseDateTime(dateRaw, timeRaw uint16) (time.Time, error) {

--- a/tdx/kline_test.go
+++ b/tdx/kline_test.go
@@ -55,6 +55,9 @@ func TestProcessDayFileIgnoresReservedForVolume(t *testing.T) {
 	if rows[0].Close != 27.75 {
 		t.Errorf("close = %f, want 27.75", rows[0].Close)
 	}
+	if rows[0].UpCount != 0 || rows[0].DownCount != 0 {
+		t.Errorf("breadth = (%d, %d), want (0, 0)", rows[0].UpCount, rows[0].DownCount)
+	}
 }
 
 func TestProcessDayFileScalesC364VolumeMarker(t *testing.T) {
@@ -80,5 +83,48 @@ func TestProcessDayFileScalesC364VolumeMarker(t *testing.T) {
 	}
 	if rows[0].Close != 3.8 {
 		t.Errorf("close = %f, want 3.8", rows[0].Close)
+	}
+}
+
+func TestProcessDayFileParsesIndexBreadth(t *testing.T) {
+	data := make([]byte, recordSize)
+	binary.LittleEndian.PutUint32(data[0:4], 20260618)
+	binary.LittleEndian.PutUint32(data[4:8], 292649)
+	binary.LittleEndian.PutUint32(data[8:12], 293535)
+	binary.LittleEndian.PutUint32(data[12:16], 291939)
+	binary.LittleEndian.PutUint32(data[16:20], 292875)
+	binary.LittleEndian.PutUint32(data[24:28], 123_456)
+	binary.LittleEndian.PutUint32(data[28:32], 0x0026000c)
+
+	rows, err := processDayFile(data, "sh000016")
+	if err != nil {
+		t.Fatalf("processDayFile: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if rows[0].Volume != 123_456 {
+		t.Errorf("volume = %d, want 123456", rows[0].Volume)
+	}
+	if rows[0].UpCount != 12 || rows[0].DownCount != 38 {
+		t.Errorf("breadth = (%d, %d), want (12, 38)", rows[0].UpCount, rows[0].DownCount)
+	}
+}
+
+func TestProcessDayFileParsesBlockBreadth(t *testing.T) {
+	data := make([]byte, recordSize)
+	binary.LittleEndian.PutUint32(data[0:4], 20260618)
+	binary.LittleEndian.PutUint32(data[24:28], 123_456)
+	binary.LittleEndian.PutUint32(data[28:32], 0x003b0024)
+
+	rows, err := processDayFile(data, "sh881044")
+	if err != nil {
+		t.Fatalf("processDayFile: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if rows[0].UpCount != 36 || rows[0].DownCount != 59 {
+		t.Errorf("breadth = (%d, %d), want (36, 59)", rows[0].UpCount, rows[0].DownCount)
 	}
 }

--- a/tdx/merge.go
+++ b/tdx/merge.go
@@ -27,12 +27,14 @@ type codEntry struct {
 
 // md1OHLCV holds OHLCV data extracted from one 512-byte block in a .md1 file.
 type md1OHLCV struct {
-	Open   float64 // [12:20] double
-	High   float64 // [20:28] double
-	Low    float64 // [28:36] double
-	Close  float64 // [36:44] double
-	Amount float64 // [72:80] double (turnover in yuan)
-	Volume uint64  // [56:64] uint64 (in shares)
+	Open      float64 // [12:20] double
+	High      float64 // [20:28] double
+	Low       float64 // [28:36] double
+	Close     float64 // [36:44] double
+	Amount    float64 // [72:80] double (turnover in yuan)
+	Volume    uint64  // [56:64] uint64 (in shares)
+	UpCount   uint32  // [152:156] uint32 (index mode only)
+	DownCount uint32  // [232:236] uint32 (index mode only)
 }
 
 // NativeDayMerge reads all .md1/.cod file pairs from vipdocDir/refmhq/ and
@@ -160,6 +162,8 @@ func parseCodEntries(codFile string) ([]codEntry, error) {
 //	[36:44] float64  close price
 //	[56:64] uint64   volume (in shares)
 //	[72:80] float64  amount (turnover in yuan)
+//	[152:156] uint32 up count (index mode only)
+//	[232:236] uint32 down count (index mode only)
 func readMd1Block(md1Data []byte, seqNum uint16) (md1OHLCV, error) {
 	offset := int(seqNum) * md1BlockSize
 	if offset+md1BlockSize > len(md1Data) {
@@ -169,12 +173,14 @@ func readMd1Block(md1Data []byte, seqNum uint16) (md1OHLCV, error) {
 	blk := md1Data[offset : offset+md1BlockSize]
 
 	return md1OHLCV{
-		Open:   math.Float64frombits(binary.LittleEndian.Uint64(blk[12:20])),
-		High:   math.Float64frombits(binary.LittleEndian.Uint64(blk[20:28])),
-		Low:    math.Float64frombits(binary.LittleEndian.Uint64(blk[28:36])),
-		Close:  math.Float64frombits(binary.LittleEndian.Uint64(blk[36:44])),
-		Volume: binary.LittleEndian.Uint64(blk[56:64]),
-		Amount: math.Float64frombits(binary.LittleEndian.Uint64(blk[72:80])),
+		Open:      math.Float64frombits(binary.LittleEndian.Uint64(blk[12:20])),
+		High:      math.Float64frombits(binary.LittleEndian.Uint64(blk[20:28])),
+		Low:       math.Float64frombits(binary.LittleEndian.Uint64(blk[28:36])),
+		Close:     math.Float64frombits(binary.LittleEndian.Uint64(blk[36:44])),
+		Volume:    binary.LittleEndian.Uint64(blk[56:64]),
+		Amount:    math.Float64frombits(binary.LittleEndian.Uint64(blk[72:80])),
+		UpCount:   binary.LittleEndian.Uint32(blk[152:156]),
+		DownCount: binary.LittleEndian.Uint32(blk[232:236]),
 	}, nil
 }
 
@@ -192,7 +198,7 @@ func readMd1Block(md1Data []byte, seqNum uint16) (md1OHLCV, error) {
 //	[28:32] uint32   reserved
 //
 // scale 由 model.PriceScale(symbol) 决定: 股票=100, ETF/LOF/B股=1000
-func makeDayRecord(date uint32, rec md1OHLCV, scale float64) []byte {
+func makeDayRecord(date uint32, rec md1OHLCV, scale float64, indexMode bool) []byte {
 	buf := make([]byte, recordSize)
 
 	binary.LittleEndian.PutUint32(buf[0:4], date)
@@ -202,9 +208,17 @@ func makeDayRecord(date uint32, rec md1OHLCV, scale float64) []byte {
 	binary.LittleEndian.PutUint32(buf[16:20], uint32(math.Round(rec.Close*scale)))
 	binary.LittleEndian.PutUint32(buf[20:24], math.Float32bits(float32(rec.Amount)))
 	volRaw, reserved := encodeDayVolume(rec.Volume)
+	if indexMode {
+		volRaw = uint32(rec.Volume)
+		reserved = encodeDayBreadth(rec.UpCount, rec.DownCount)
+	}
 	binary.LittleEndian.PutUint32(buf[24:28], volRaw)
 	binary.LittleEndian.PutUint32(buf[28:32], reserved)
 	return buf
+}
+
+func encodeDayBreadth(upCount, downCount uint32) uint32 {
+	return upCount&0xffff | (downCount&0xffff)<<16
 }
 
 // encodeDayVolume converts the uint64 volume stored in .md1 into the compact
@@ -254,7 +268,7 @@ func mergeSingleDay(vipdocDir, exchange string, date uint32, codFile, md1File st
 
 		symbol := exchange + ent.StockCode
 		scale := model.PriceScale(symbol)
-		dayRec := makeDayRecord(date, ohlcv, scale)
+		dayRec := makeDayRecord(date, ohlcv, scale, isIndexMode(symbol))
 
 		if err := appendDayRecord(dayFilePath, date, dayRec); err != nil {
 			continue

--- a/tdx/merge.go
+++ b/tdx/merge.go
@@ -32,7 +32,7 @@ type md1OHLCV struct {
 	Low    float64 // [28:36] double
 	Close  float64 // [36:44] double
 	Amount float64 // [72:80] double (turnover in yuan)
-	Volume uint32  // [56:60] uint32 (in shares)
+	Volume uint64  // [56:64] uint64 (in shares)
 }
 
 // NativeDayMerge reads all .md1/.cod file pairs from vipdocDir/refmhq/ and
@@ -158,7 +158,7 @@ func parseCodEntries(codFile string) ([]codEntry, error) {
 //	[20:28] float64  high price
 //	[28:36] float64  low price
 //	[36:44] float64  close price
-//	[56:60] uint32   volume (in shares)
+//	[56:64] uint64   volume (in shares)
 //	[72:80] float64  amount (turnover in yuan)
 func readMd1Block(md1Data []byte, seqNum uint16) (md1OHLCV, error) {
 	offset := int(seqNum) * md1BlockSize
@@ -173,7 +173,7 @@ func readMd1Block(md1Data []byte, seqNum uint16) (md1OHLCV, error) {
 		High:   math.Float64frombits(binary.LittleEndian.Uint64(blk[20:28])),
 		Low:    math.Float64frombits(binary.LittleEndian.Uint64(blk[28:36])),
 		Close:  math.Float64frombits(binary.LittleEndian.Uint64(blk[36:44])),
-		Volume: binary.LittleEndian.Uint32(blk[56:60]),
+		Volume: binary.LittleEndian.Uint64(blk[56:64]),
 		Amount: math.Float64frombits(binary.LittleEndian.Uint64(blk[72:80])),
 	}, nil
 }
@@ -201,9 +201,20 @@ func makeDayRecord(date uint32, rec md1OHLCV, scale float64) []byte {
 	binary.LittleEndian.PutUint32(buf[12:16], uint32(math.Round(rec.Low*scale)))
 	binary.LittleEndian.PutUint32(buf[16:20], uint32(math.Round(rec.Close*scale)))
 	binary.LittleEndian.PutUint32(buf[20:24], math.Float32bits(float32(rec.Amount)))
-	binary.LittleEndian.PutUint32(buf[24:28], rec.Volume)
-	binary.LittleEndian.PutUint32(buf[28:32], 0x10000)
+	volRaw, reserved := encodeDayVolume(rec.Volume)
+	binary.LittleEndian.PutUint32(buf[24:28], volRaw)
+	binary.LittleEndian.PutUint32(buf[28:32], reserved)
 	return buf
+}
+
+// encodeDayVolume converts the uint64 volume stored in .md1 into the compact
+// .day representation. Volumes larger than uint32 use TDX's x100 overflow
+// marker: the quotient is stored in volume and the remainder in reserved.
+func encodeDayVolume(volume uint64) (volRaw, reserved uint32) {
+	if volume <= math.MaxUint32 {
+		return uint32(volume), 0x10000
+	}
+	return uint32(volume / 100), 0xc3640000 | uint32(volume%100)
 }
 
 // mergeSingleDay processes one .cod+.md1 pair for a single exchange and date,

--- a/tdx/merge_test.go
+++ b/tdx/merge_test.go
@@ -51,7 +51,7 @@ func TestMakeDayRecord(t *testing.T) {
 		Volume: 3555100,
 	}
 
-	buf := makeDayRecord(20260318, rec, 100)
+	buf := makeDayRecord(20260318, rec, 100, false)
 
 	if len(buf) != recordSize {
 		t.Fatalf("expected %d bytes, got %d", recordSize, len(buf))
@@ -112,7 +112,7 @@ func TestMakeDayRecord(t *testing.T) {
 
 func TestMakeDayRecordEncodesOverflowVolume(t *testing.T) {
 	rec := md1OHLCV{Volume: 8_285_468_730}
-	buf := makeDayRecord(20260320, rec, 1000)
+	buf := makeDayRecord(20260320, rec, 1000, false)
 
 	volRaw := binary.LittleEndian.Uint32(buf[24:28])
 	reserved := binary.LittleEndian.Uint32(buf[28:32])
@@ -124,12 +124,25 @@ func TestMakeDayRecordEncodesOverflowVolume(t *testing.T) {
 	}
 }
 
+func TestMakeDayRecordEncodesIndexBreadth(t *testing.T) {
+	rec := md1OHLCV{Volume: 123_456, UpCount: 12, DownCount: 38}
+	buf := makeDayRecord(20260618, rec, 100, true)
+
+	if got := binary.LittleEndian.Uint32(buf[24:28]); got != 123_456 {
+		t.Errorf("volume = %d, want 123456", got)
+	}
+	reserved := binary.LittleEndian.Uint32(buf[28:32])
+	if reserved != 0x0026000c {
+		t.Errorf("reserved = %#x, want 0x0026000c", reserved)
+	}
+}
+
 func TestAppendDayRecordDedup(t *testing.T) {
 	tmpDir := t.TempDir()
 	dayFile := filepath.Join(tmpDir, "test.day")
 
 	rec := md1OHLCV{Open: 10, High: 11, Low: 9, Close: 10.5, Amount: 1000, Volume: 100}
-	buf := makeDayRecord(20260318, rec, 100)
+	buf := makeDayRecord(20260318, rec, 100, false)
 
 	// First write
 	if err := appendDayRecord(dayFile, 20260318, buf); err != nil {
@@ -152,7 +165,7 @@ func TestAppendDayRecordDedup(t *testing.T) {
 	}
 
 	// Older date — should also be skipped
-	oldBuf := makeDayRecord(20260317, rec, 100)
+	oldBuf := makeDayRecord(20260317, rec, 100, false)
 	if err := appendDayRecord(dayFile, 20260317, oldBuf); err != nil {
 		t.Fatalf("old date append: %v", err)
 	}
@@ -163,7 +176,7 @@ func TestAppendDayRecordDedup(t *testing.T) {
 	}
 
 	// Newer date — should be appended
-	newBuf := makeDayRecord(20260319, rec, 100)
+	newBuf := makeDayRecord(20260319, rec, 100, false)
 	if err := appendDayRecord(dayFile, 20260319, newBuf); err != nil {
 		t.Fatalf("new date append: %v", err)
 	}
@@ -222,6 +235,8 @@ func TestReadMd1Block(t *testing.T) {
 	binary.LittleEndian.PutUint64(data[36:44], math.Float64bits(103.25))  // close
 	binary.LittleEndian.PutUint64(data[56:64], 8_285_468_730)             // volume
 	binary.LittleEndian.PutUint64(data[72:80], math.Float64bits(5000000)) // amount
+	binary.LittleEndian.PutUint32(data[152:156], 12)                      // up count
+	binary.LittleEndian.PutUint32(data[232:236], 38)                      // down count
 
 	ohlcv, err := readMd1Block(data, 0)
 	if err != nil {
@@ -245,6 +260,9 @@ func TestReadMd1Block(t *testing.T) {
 	}
 	if ohlcv.Amount != 5000000 {
 		t.Errorf("amount = %f, want 5000000", ohlcv.Amount)
+	}
+	if ohlcv.UpCount != 12 || ohlcv.DownCount != 38 {
+		t.Errorf("breadth = (%d, %d), want (12, 38)", ohlcv.UpCount, ohlcv.DownCount)
 	}
 
 	// Out of range

--- a/tdx/merge_test.go
+++ b/tdx/merge_test.go
@@ -110,6 +110,20 @@ func TestMakeDayRecord(t *testing.T) {
 	}
 }
 
+func TestMakeDayRecordEncodesOverflowVolume(t *testing.T) {
+	rec := md1OHLCV{Volume: 8_285_468_730}
+	buf := makeDayRecord(20260320, rec, 1000)
+
+	volRaw := binary.LittleEndian.Uint32(buf[24:28])
+	reserved := binary.LittleEndian.Uint32(buf[28:32])
+	if reserved&0xffffff00 != 0xc3640000 {
+		t.Fatalf("reserved = %#x, want c364 overflow marker", reserved)
+	}
+	if got := parseDayVolume(volRaw, reserved); got != int64(rec.Volume) {
+		t.Errorf("parseDayVolume round-trip = %d, want %d", got, rec.Volume)
+	}
+}
+
 func TestAppendDayRecordDedup(t *testing.T) {
 	tmpDir := t.TempDir()
 	dayFile := filepath.Join(tmpDir, "test.day")
@@ -206,7 +220,7 @@ func TestReadMd1Block(t *testing.T) {
 	binary.LittleEndian.PutUint64(data[20:28], math.Float64bits(105.00))  // high
 	binary.LittleEndian.PutUint64(data[28:36], math.Float64bits(99.00))   // low
 	binary.LittleEndian.PutUint64(data[36:44], math.Float64bits(103.25))  // close
-	binary.LittleEndian.PutUint32(data[56:60], 50000)                     // volume
+	binary.LittleEndian.PutUint64(data[56:64], 8_285_468_730)             // volume
 	binary.LittleEndian.PutUint64(data[72:80], math.Float64bits(5000000)) // amount
 
 	ohlcv, err := readMd1Block(data, 0)
@@ -226,8 +240,8 @@ func TestReadMd1Block(t *testing.T) {
 	if ohlcv.Close != 103.25 {
 		t.Errorf("close = %f, want 103.25", ohlcv.Close)
 	}
-	if ohlcv.Volume != 50000 {
-		t.Errorf("volume = %d, want 50000", ohlcv.Volume)
+	if ohlcv.Volume != 8_285_468_730 {
+		t.Errorf("volume = %d, want 8285468730", ohlcv.Volume)
 	}
 	if ohlcv.Amount != 5000000 {
 		t.Errorf("amount = %f, want 5000000", ohlcv.Amount)


### PR DESCRIPTION
修复 #122 

## 变更概述

- 将 `.md1` 的成交量按 `[56:64]` little-endian `uint64` 读取，修复高成交量 ETF 超过 `math.MaxUint32` 后被截断的问题
- 将大于 `uint32` 的 `.md1` 成交量无损编码为 TDX `.day` 溢出格式，保留不足 100 份的余数
- 对指数和板块标的，将 `.day` 的 `reserved` 解析为 `up_count/down_count`
- 从 `.md1` offset 152 和 232 读取指数涨跌家数，并在生成 `.day` 时保留
- 为 `raw_kline_daily` 新增 `up_count`、`down_count` 字段
- 数据库 schema 从 v5.0 升级到 v6.0

## 问题根因

`.md1` 与 `.day` 使用了不同的成交量编码：

- `.md1` 在 `[56:64]` 直接保存 little-endian `uint64` 成交量
- `.day` 通常在 `[24:28]` 保存 `uint32` 成交量；超出范围时，使用 `reserved` 中的 `0xc364xxxx` 标记，低 8 位保存不足 100 份的余数

原来的 `readMd1Block` 只把 `[56:60]` 读取为 `uint32`。该逻辑对大部分股票看起来正常，但高成交量 ETF 的高 32 位不为零时会发生截断。

`.day` 的 `reserved` 还会根据标的类型复用。对于指数和板块，它是 little-endian `<HH>` 格式的涨跌家数：

```text
up_count   = reserved & 0xffff
down_count = reserved >> 16
```

对于普通股票和 ETF，`reserved` 不是涨跌家数，而是常规保留值、未使用值或 `0xc364xxxx` 成交量溢出标记。因此必须先根据 symbol 分类选择解析方式，不能只看 `reserved` 的数值。

## 实现说明

- 将 `md1OHLCV.Volume` 从 `uint32` 改为 `uint64`
- 使用 `binary.LittleEndian.Uint64(blk[56:64])` 读取 `.md1` 成交量
- 新增 `encodeDayVolume`，实现 `.md1 -> .day` 成交量无损转换
- 将 `.md1` 的 `uint32@152`、`uint32@232` 分别读取为上涨、下跌家数
- 统一判断 `index`、`block` 两类指数模式标的
- 仅在指数模式下解析和写入 `.day` 涨跌家数
- 为 `KlineDay` 新增 `UpCount`、`DownCount`
- 将数据库 schema 从 v5.0 升级到 v6.0

## 真实数据验证

### ETF 成交量溢出：`sz159518`，2026-03-20

通达信官方增量文件解析结果：

| 字段 | 旧解析方式 | 修复后 |
|---|---:|---:|
| 成交量 | 3,990,501,434 | 8,285,468,730 |
| `amount / (volume * close)` | 2.1259 | 1.0239 |

其他行情字段：

```text
open=1.240
high=1.378
low=1.230
close=1.298
amount=11,011,584,416.508
```

东方财富返回的 OHLC 和成交额与 TDX 完全一致，成交量为 `82,854,687` 手。该值与生成的 `.day` `volRaw` 完全相同，剩余 30 份保存在 `reserved=0xc364001e` 中：

```text
82,854,687 * 100 + 0x1e = 8,285,468,730
```

### 指数涨跌家数：`sh000016`，2026-06-18

通达信官方数据：

```text
.day reserved       = 0x0026000c
.md1 uint32@152     = 12
.md1 uint32@232     = 38
解析结果              = 上涨 12 / 下跌 38
```

作为独立校验，从东方财富取得上证50的50只成分股，逐只读取 `2026-06-18` 日线并按涨跌额重新统计，结果同样是上涨 12、下跌 38。

其他 TDX 样本：

| 标的 | `reserved` | 上涨 | 下跌 | 合计 |
|---|---:|---:|---:|---:|
| `sh000001` | `0x05700396` | 918 | 1,392 | 2,310 |
| `sh000300` | `0x00dc0050` | 80 | 220 | 300 |
| `sh881044` | `0x003b0024` | 36 | 59 | 95 |

## 测试情况

- [x] `go test ./tdx ./model`
- [x] `go vet ./tdx ./model`
- [x] 真实 `.day` 回归：`sh000016` 解析为上涨 12、下跌 38
- [x] 真实 `.md1` 回归：`sz159518` 成交量解析为 8,285,468,730
- [x] 使用东方财富数据交叉验证 ETF 成交量和指数涨跌家数

本地 Windows 环境未能完成 `go test ./...`：DuckDB Windows binding 依赖 cgo 和 GCC，而当前环境为 `CGO_ENABLED=0` 且没有 GCC。本 PR 直接修改的 `tdx`、`model` 包已通过针对性测试和静态检查。

## 破坏性变更与迁移

`raw_kline_daily` 新增两个非空整数字段：

```text
up_count
down_count
```

schema 升级到 v6.0，使已有 v5 数据库在启动时明确报版本不兼容，避免将新增两列的 CSV 导入旧表结构。已有数据库需要迁移或重新初始化后，才能使用该版本运行 `cron`。

## 提交记录

```text
f5b93f3 fix: preserve overflowing md1 volume
829c98e feat!: import index breadth counts
```
